### PR TITLE
Cedar

### DIFF
--- a/code/01_fmriprep_fit_scinet.sh
+++ b/code/01_fmriprep_fit_scinet.sh
@@ -96,20 +96,17 @@ singularity run --cleanenv \
 #   --skull-strip-t1w force \ # uncomment this line if skull stripping has aleady been done
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
-
-    BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
-    
+    cd "${ROOT_DIR}/Neurobagel"
     mkdir -p derivatives/fmriprepfit/23.2.3/output/
     ls -al derivatives/fmriprepfit/23.2.3/output
-
-    ln -s "$BASEDIR/data/local/derivatives/fmriprep/23.2.3/"* derivatives/fmriprepfit/23.2.3/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/fmriprep/23.2.3/"* derivatives/fmriprepfit/23.2.3/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -118,3 +115,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/01_freesurfer_long_scinet.sh
+++ b/code/01_freesurfer_long_scinet.sh
@@ -87,19 +87,18 @@ singularity run --cleanenv \
 #   --skull-strip-t1w force \ # uncomment this line if skull stripping has aleady been done
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
-    
+    cd "${ROOT_DIR}/Neurobagel"    
     mkdir -p derivatives/freesurferlong/7.4.1/output/
     ls -al derivatives/freesurferlong/7.4.1/output/
-    ln -s "$BASEDIR/data/local/derivatives/freesurfer/7.4.1/"* derivatives/freesurferlong/7.4.1/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/freesurfer/7.4.1/"* derivatives/freesurferlong/7.4.1/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -108,3 +107,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/01_magetbrain_init_scinet.sh
+++ b/code/01_magetbrain_init_scinet.sh
@@ -174,19 +174,21 @@ cp -r /scratch/arisvoin/shared/templateflow/atlases  "$INPUT_DIR/"
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${PROJECT_DIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${PROJECT_DIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/magetbraininit/0.1.0/output/
     ls -al derivatives/magetbraininit/0.1.0/output/
-    ln -s "$BASEDIR/data/local/derivatives/MAGeTbrain/magetbrain_data/"* derivatives/magetbraininit/0.1.0/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/"* derivatives/magetbraininit/0.1.0/output/ || true
 
     nipoppy track  --pipeline magetbraininit   --pipeline-version 0.1.0 
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/01_mriqc_scinet.sh
+++ b/code/01_mriqc_scinet.sh
@@ -81,19 +81,18 @@ singularity run --cleanenv \
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
-    
+    cd "${ROOT_DIR}}/Neurobagel"
     mkdir -p derivatives/mriqc/24.0.0/output/
     ls -al derivatives/mriqc/24.0.0/output/
-    ln -s "$BASEDIR/data/local/derivatives/mriqc/24.0.0/"* derivatives/mriqc/24.0.0/output/ || true
+    ln -s "${ROOT_DIR}}/data/local/derivatives/mriqc/24.0.0/"* derivatives/mriqc/24.0.0/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -102,3 +101,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/01_smriprep_scinet.sh
+++ b/code/01_smriprep_scinet.sh
@@ -74,19 +74,18 @@ singularity exec --cleanenv \
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
-    
+    cd "${ROOT_DIR}}/Neurobagel"
     mkdir -p derivatives/smriprep/23.2.3/output/
     ls -al derivatives/smriprep/23.2.3/output/
-    ln -s "$BASEDIR/data/local/derivatives/smriprep/23.2.3/smriprep/"* derivatives/smriprep/23.2.3/output/ || true
+    ln -s "${ROOT_DIR}}/data/local/derivatives/smriprep/23.2.3/smriprep/"* derivatives/smriprep/23.2.3/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -95,3 +94,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/02_ciftify_anat_scinet.sh
+++ b/code/02_ciftify_anat_scinet.sh
@@ -66,20 +66,21 @@ fi
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/ciftify/1.3.2/output/
     ls -al derivatives/ciftify/1.3.2/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/ciftify/"* derivatives/ciftify/1.3.2/output/ || true
+    ln -s "$ROOT_DIR/data/local/derivatives/ciftify/"* derivatives/ciftify/1.3.2/output/ || true
 
     SUBJECTS=$(echo "$SELECTED_SUBJECT" | cut -d'_' -f1)
 
@@ -90,3 +91,4 @@ singularity exec \
         --participant-id $subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/02_fmriprep_apply_scinet.sh
+++ b/code/02_fmriprep_apply_scinet.sh
@@ -87,20 +87,21 @@ singularity run --cleanenv \
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}}/Neurobagel"
     
     mkdir -p derivatives/fmriprepapply/23.2.3/output/
     ls -al derivatives/fmriprepapply/23.2.3/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/fmriprep/23.2.3/"* derivatives/fmriprepapply/23.2.3/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/fmriprep/23.2.3/"* derivatives/fmriprepapply/23.2.3/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -109,3 +110,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/02_freesurfer_group_scinet.sh
+++ b/code/02_freesurfer_group_scinet.sh
@@ -143,20 +143,21 @@ EOF
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS_BATCH="$SUBJECTS_BATCH" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}}/Neurobagel"
     
     mkdir -p derivatives/freesurfergroup/7.4.1/output/
     ls -al derivatives/freesurfergroup/7.4.1/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/freesurfer/7.4.1/"* derivatives/freesurfergroup/7.4.1/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/freesurfer/7.4.1/"* derivatives/freesurfergroup/7.4.1/output/ || true
 
     for subject in $SUBJECTS_BATCH; do
       nipoppy track \
@@ -165,3 +166,4 @@ singularity exec \
         --participant-id $subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/02_magetbrain_register_scinet.sh
+++ b/code/02_magetbrain_register_scinet.sh
@@ -35,20 +35,22 @@ singularity run \
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${PROJECT_DIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS_BATCH="$SUBJECTS_BATCH" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${PROJECT_DIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/magetbrainregister/0.1.0/output/
     ls -al derivatives/magetbrainregister/0.1.0/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/MAGeTbrain/magetbrain_data/"* derivatives/magetbrainregister/0.1.0/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/"* derivatives/magetbrainregister/0.1.0/output/ || true
 
     nipoppy track  --pipeline magetbrainregister  --pipeline-version 0.1.0
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/02_qsiprep_scinet.sh
+++ b/code/02_qsiprep_scinet.sh
@@ -113,20 +113,21 @@ singularity run --cleanenv \
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/qsiprep/0.22.0/output/
     ls -al derivatives/qsiprep/0.22.0/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/qsiprep/0.22.0/qsiprep/"* derivatives/qsiprep/0.22.0/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep/"* derivatives/qsiprep/0.22.0/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -135,3 +136,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/03_amico_noddi.sh
+++ b/code/03_amico_noddi.sh
@@ -78,20 +78,21 @@ singularity run --cleanenv \
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/amiconoddi/0.22.0/output/
     ls -al derivatives/amiconoddi/0.22.0/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/qsiprep/0.22.0/amico_noddi/"* derivatives/amiconoddi/0.22.0/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/qsiprep/0.22.0/amico_noddi/"* derivatives/amiconoddi/0.22.0/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -100,3 +101,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/03_magetbrain_vote_scinet.sh
+++ b/code/03_magetbrain_vote_scinet.sh
@@ -48,20 +48,21 @@ singularity run \
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${PROJECT_DIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/magetbrainvote/0.1.0/output/
     ls -al derivatives/magetbrainvote/0.1.0/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/MAGeTbrain/magetbrain_data/output/"* derivatives/magetbrainvote/0.1.0/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/output/"* derivatives/magetbrainvote/0.1.0/output/ || true
 
     SUBJECTS=$(echo "$SUBJECTS" | cut -d'_' -f1)
 
@@ -72,3 +73,4 @@ singularity exec \
         --participant-id $subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/03_qsirecon_step1_scinet.sh
+++ b/code/03_qsirecon_step1_scinet.sh
@@ -86,20 +86,21 @@ singularity run --cleanenv \
     --notrack
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/qsirecon1/0.22.0/output/
     ls -al derivatives/qsirecon1/0.22.0/output/
 
-    ln -s "$BASEDIR/data/local/qsirecon-FSL/" derivatives/qsirecon1/0.22.0/output/ || true
+    ln -s "${ROOT_DIR}/data/local/qsirecon-FSL/" derivatives/qsirecon1/0.22.0/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -108,3 +109,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR 

--- a/code/03_tractography_multi_scinet.sh
+++ b/code/03_tractography_multi_scinet.sh
@@ -89,20 +89,21 @@ singularity run --cleanenv \
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/tractographymulti/0.22.0/output/
     ls -al derivatives/tractographymulti/0.22.0/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/qsiprep/0.22.0/qsirecon-MRtrix3_act-HSVS/" derivatives/tractographymulti/0.22.0/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/qsiprep/0.22.0/qsirecon-MRtrix3_act-HSVS/" derivatives/tractographymulti/0.22.0/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -111,3 +112,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/03_tractography_single_scinet.sh
+++ b/code/03_tractography_single_scinet.sh
@@ -89,20 +89,21 @@ singularity run --cleanenv \
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR} 
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/tractographysingle/0.22.0/output/
     ls -al derivatives/tractographysingle/0.22.0/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/qsiprep/0.22.0/qqsirecon-MRtrix3_fork-SS3T_act-HSVS/" derivatives/tractographysingle/0.22.0/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/qsiprep/0.22.0/qqsirecon-MRtrix3_fork-SS3T_act-HSVS/" derivatives/tractographysingle/0.22.0/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -111,3 +112,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/03_xcp_noGSR_scinet.sh
+++ b/code/03_xcp_noGSR_scinet.sh
@@ -145,20 +145,21 @@ ${SING_CONTAINER} \
 # note, if you have top-up fieldmaps than you can uncomment the last two lines of the above script
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/xcpnogsr/0.7.3/output/
     ls -al derivatives/xcpnogsr/0.7.3/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/xcp_noGSR/"* derivatives/xcpnogsr/0.7.3/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/xcp_noGSR/"* derivatives/xcpnogsr/0.7.3/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -167,3 +168,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/03_xcp_scinet.sh
+++ b/code/03_xcp_scinet.sh
@@ -79,20 +79,21 @@ ${SING_CONTAINER} \
 # note, if you have top-up fieldmaps than you can uncomment the last two lines of the above script
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/xcpd/0.7.3/output/
     ls -al derivatives/xcpd/0.7.3/output/
 
-    ln -s "$BASEDIR/data/local/derivatives/xcp_d/0.7.3/"* derivatives/xcpd/0.7.3/output/ || true
+    ln -s "${ROOT_DIR}/data/local/derivatives/xcp_d/0.7.3/"* derivatives/xcpd/0.7.3/output/ || true
 
     for subject in $SUBJECTS; do
       nipoppy track \
@@ -101,3 +102,4 @@ singularity exec \
         --participant-id sub-$subject
     done
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/04_qsirecon_step2_scinet.sh
+++ b/code/04_qsirecon_step2_scinet.sh
@@ -133,22 +133,22 @@ if [ -z "$SESSIONS" ]; then
       
 
     ## nipoppy trackers 
-
+    export APPTAINERENV_ROOT_DIR=${BASEDIR}
     singularity exec \
   	--bind ${SCRATCH}:${SCRATCH} \
   	--env SUBJECTS="$SUBJECTS" \
-  	containers/nipoppy.sif /bin/bash -c '
+  	${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     	set -euo pipefail
 
     	BASEDIR="$SCRATCH/SCanD_project"
-    	cd "$BASEDIR/Neurobagel"
+    	cd "${ROOT_DIR}/Neurobagel"
     
     	mkdir -p derivatives/qsirecon2/0.22.0/output/
     	ls -al derivatives/qsirecon2/0.22.0/output/
 
-    	ln -s "$BASEDIR/data/local/dtifit/" derivatives/qsirecon2/0.22.0/output/ || true
+    	ln -s "${ROOT_DIR}/data/local/dtifit/" derivatives/qsirecon2/0.22.0/output/ || true
     	ls -al derivatives/qsirecon2/0.22.0/output/
-    	ln -s "$BASEDIR/data/local/enigmaDTI/" derivatives/qsirecon2/0.22.0/output/ || true
+    	ln -s "${ROOT_DIR}/data/local/enigmaDTI/" derivatives/qsirecon2/0.22.0/output/ || true
 
     	for subject in $SUBJECTS; do
       	nipoppy track \
@@ -157,7 +157,7 @@ if [ -z "$SESSIONS" ]; then
         	--participant-id sub-$subject
     	done
   	'
-
+    unset APPTAINERENV_ROOT_DIR
 
 else
 
@@ -225,22 +225,23 @@ else
 
 
         ## nipoppy trackers 
+    export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
  	singularity exec \
   	--bind ${SCRATCH}:${SCRATCH} \
   	--env SUBJECTS="$SUBJECTS" \
-  	containers/nipoppy.sif /bin/bash -c '
+  	${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     	set -euo pipefail
 
     	BASEDIR="$SCRATCH/SCanD_project"
-    	cd "$BASEDIR/Neurobagel"
+    	cd "${ROOT_DIR}/Neurobagel"
     
     	mkdir -p derivatives/qsirecon2/0.22.0/output/
     	ls -al derivatives/qsirecon2/0.22.0/output/
 
-    	ln -s "$BASEDIR/data/local/dtifit/" derivatives/qsirecon2/0.22.0/output/ || true
+    	ln -s "${ROOT_DIR}/data/local/dtifit/" derivatives/qsirecon2/0.22.0/output/ || true
         ls -al derivatives/qsirecon2/0.22.0/output/
-    	ln -s "$BASEDIR/data/local/enigmaDTI/" derivatives/qsirecon2/0.22.0/output/ || true
+    	ln -s "${ROOT_DIR}/data/local/enigmaDTI/" derivatives/qsirecon2/0.22.0/output/ || true
 
     	for subject in $SUBJECTS; do
       	nipoppy track \
@@ -249,7 +250,7 @@ else
         	--participant-id sub-$subject
     	done
   	'
-
+    unset APPTAINERENV_ROOT_DIR
     done
    
 fi

--- a/code/05_enigma_dti_scinet.sh
+++ b/code/05_enigma_dti_scinet.sh
@@ -54,20 +54,22 @@ EOF
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/enigmadti/0.1.1/output/
     ls -al derivatives/enigmadti/0.1.1/output/
 
-    ln -s "$BASEDIR/data/local/data/local/enigmaDTI/" derivatives/enigmadti/0.1.1/output/ || true
+    ln -s "${ROOT_DIR}/data/local/data/local/enigmaDTI/" derivatives/enigmadti/0.1.1/output/ || true
 
     nipoppy track  --pipeline enigmadti  --pipeline-version 0.1.1 
   '
+unset APPTAINERENV_ROOT_DIR

--- a/code/06_extract_noddi_scinet.sh
+++ b/code/06_extract_noddi_scinet.sh
@@ -43,20 +43,22 @@ done
 
 
 ## nipoppy trackers 
+export APPTAINERENV_ROOT_DIR=${BASEDIR}
 
 singularity exec \
   --bind ${SCRATCH}:${SCRATCH} \
   --env SUBJECTS="$SUBJECTS" \
-  containers/nipoppy.sif /bin/bash -c '
+  ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
     BASEDIR="$SCRATCH/SCanD_project"
-    cd "$BASEDIR/Neurobagel"
+    cd "${ROOT_DIR}}/Neurobagel"
     
     mkdir -p derivatives/extractnoddi/0.1.1/output/
     ls -al derivatives/extractnoddi/0.1.1/output/
 
-    ln -s "$BASEDIR/data/local/data/local/derivatives/qsiprep/0.22.0/amico_noddi/qsirecon-NODDI/" derivatives/extractnoddi/0.1.1/output/ || true
+    ln -s "${ROOT_DIR}/data/local/data/local/derivatives/qsiprep/0.22.0/amico_noddi/qsirecon-NODDI/" derivatives/extractnoddi/0.1.1/output/ || true
 
     nipoppy track  --pipeline extractnoddi  --pipeline-version 0.1.1 
   '
+unset APPTAINERENV_ROOT_DIR


### PR DESCRIPTION
Update scripts in Cedar to handle hardcode paths, add file existence checks avoiding over-written of the participants.tsv, and unset SSL_CERT_FILE in run 00_nipoppy_trackers