### PR TITLE
Fix P0 portability and docs for SCanD preprocessing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,11 +222,11 @@ virtualenv --system-site-packages ~/.virtualenvs/myenv
 ## Activate the virtual environment
 source ~/.virtualenvs/myenv/bin/activate 
 
-python3 -m pip install pybids=0.15.6
+python3 -m pip install pybids==0.15.6
 
 cd $SCRATCH/SCanD_project
 
-python3 code/fmap_intended_for.py ./data/local/bids --participant-label ./data/local/bids/participants.tsv --config ./EPIPHANI_query_config.yaml
+python3 code/fmap_intended_for.py ./data/local/bids --participant-label ./data/local/bids/participants.tsv --config ./code/config/EPIPHANI_query_config.yaml
 ```
 ### 2. What the script does
 1. Searches your BIDS dataset for fieldmaps (/fmap)
@@ -583,7 +583,7 @@ python3 -m pip install pybids==0.15.6 rich
 
 ## Go to the repo 
 cd ${SCRATCH}/SCanD_project
-python3 ./code/check_fmap_json.py ./data/local/bids/participants.tsv
+python3 code/check_fmap_json.py ./data/local/bids ./data/local/bids/participants.tsv
 ```
 **3. Interpret the output**
 
@@ -864,7 +864,7 @@ If you do not plan to run stage 6 (data sharing) and only wish to obtain the Fre
 cd ${SCRATCH}/SCanD_project
 git pull
 
-source ./code/freesurfer_group_merge_scinet.sh
+bash ./code/freesurfer_group_merge.sh
 ```
 
 ## Running tractography

--- a/code/01_magetbrain_init_scinet.sh
+++ b/code/01_magetbrain_init_scinet.sh
@@ -184,7 +184,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/magetbraininit/0.1.0/output/

--- a/code/01_qsiprep_scinet.sh
+++ b/code/01_qsiprep_scinet.sh
@@ -142,7 +142,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/qsiprep/0.22.0/output/

--- a/code/02_amico_noddi_scinet.sh
+++ b/code/02_amico_noddi_scinet.sh
@@ -85,7 +85,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/amiconoddi/0.22.0/output/

--- a/code/02_ciftify_anat_scinet.sh
+++ b/code/02_ciftify_anat_scinet.sh
@@ -78,7 +78,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/ciftify/1.3.2/output/

--- a/code/02_fmriprep_apply_scinet.sh
+++ b/code/02_fmriprep_apply_scinet.sh
@@ -96,7 +96,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/fmriprepapply/25.2.4/output/

--- a/code/02_freesurfer_atlas_parcellate_scinet.sh
+++ b/code/02_freesurfer_atlas_parcellate_scinet.sh
@@ -169,7 +169,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/freesurferparcellate/7.4.1/output/

--- a/code/02_magetbrain_register_scinet.sh
+++ b/code/02_magetbrain_register_scinet.sh
@@ -43,7 +43,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/magetbrainregister/0.1.0/output/

--- a/code/02_qsirecon_FSL_scinet.sh
+++ b/code/02_qsirecon_FSL_scinet.sh
@@ -93,7 +93,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/qsireconfsl/0.22.0/output/

--- a/code/02_tractography_multi_scinet.sh
+++ b/code/02_tractography_multi_scinet.sh
@@ -101,7 +101,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/tractographymulti/0.22.0/output/

--- a/code/02_tractography_single_scinet.sh
+++ b/code/02_tractography_single_scinet.sh
@@ -101,7 +101,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/tractographysingle/0.22.0/output/

--- a/code/03_amico_VNC.sh
+++ b/code/03_amico_VNC.sh
@@ -5,9 +5,9 @@ BASEDIR=${SCRIPT_DIR}/..
 module load apptainer/1.3.5
 
 export BIDS_DIR=${BASEDIR}/data/local/bids
-export QSIPREP_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.4/qsiprep
+export QSIPREP_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep
 export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
-export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.4/amico_noddi
+export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/amico_noddi
 export TMP_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/amico_noddi/tmp
 export WORK_DIR=${SLURM_TMPDIR}/SCanD/amico
 export LOGS_DIR=${BASEDIR}/logs

--- a/code/03_magetbrain_vote_scinet.sh
+++ b/code/03_magetbrain_vote_scinet.sh
@@ -56,7 +56,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/magetbrainvote/0.1.0/output/

--- a/code/03_noddi_reg_scinet.sh
+++ b/code/03_noddi_reg_scinet.sh
@@ -344,7 +344,6 @@ singularity exec \
   "${BASEDIR}/containers/nipoppy.sif" /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
 
     mkdir -p derivatives/noddireg/0.22.0/output/

--- a/code/03_xcp_noGSR_scinet.sh
+++ b/code/03_xcp_noGSR_scinet.sh
@@ -152,7 +152,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/xcpnogsr/0.7.3/output/

--- a/code/03_xcp_scinet.sh
+++ b/code/03_xcp_scinet.sh
@@ -86,7 +86,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/xcpd/0.7.3/output/

--- a/code/04_enigma_dti_scinet.sh
+++ b/code/04_enigma_dti_scinet.sh
@@ -62,7 +62,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/enigmadti/0.1.1/output/

--- a/code/05_extract_noddi_scinet.sh
+++ b/code/05_extract_noddi_scinet.sh
@@ -51,7 +51,6 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    BASEDIR="$SCRATCH/SCanD_project"
     cd "${ROOT_DIR}/Neurobagel"
     
     mkdir -p derivatives/extractnoddi/0.1.1/output/


### PR DESCRIPTION
Correct FreeSurfer group merge output path and AMICO QC QSIPrep version; remove hardcoded SCRATCH/SCanD_project from nipoppy tracker blocks; update README for manifest transfer, fieldmap QC commands, and single-volume PA EPI.