### PR TITLE
Fix share script GLM copy, docs, and pipeline consistency.

### DIFF
--- a/QC_guide.md
+++ b/QC_guide.md
@@ -2,8 +2,6 @@
 
 Here are guidelines to QC each pipeline results.
 
-Reference screenshots are not bundled in this repository; use the criteria below when reviewing HTML reports and figures under `data/local/derivatives/`.
-
 ---
 
 ## fmriprep
@@ -16,9 +14,13 @@ Reference screenshots are not bundled in this repository; use the criteria below
    - Red outline (skullstrip) doesn’t include skull, outlines the brain  
    - Blue outline traces white matter area (lighter parts of brain)
 
+   ![image](figures/Good_BET.png)
+
 2) **Good MNI wrap**
    - “Participant” brain only includes brain (no skull being included)  
    - Make sure that the brain isn’t being stretched down into the cerebellum (indicative of BET segmentation issue)
+
+   ![image](figures/Good_MNI.png)
 
 ---
 
@@ -30,17 +32,25 @@ Reference screenshots are not bundled in this repository; use the criteria below
    - The red/blue outlines should align with the functional image (darker/fuzzier image)  
    - Bright white parts of the functional image should be mostly excluded from the red/blue outline
 
+   ![image](figures/EPI_to_T1.png)
+
 2) **Good SDC correction**
 
-   The “After” image should more closely align with the blue outline than the “Before” image.
+   The “After” Image should more closely align with the blue outline than the “Before” image.
+
+   ![image](figures/SDC_correction.png)
 
 3) **Clipping**
 
    In some cases the bottom part of the cerebellum gets clipped, this is acceptable (a pass) but should still be annotated as having a Clipping issue. However, if any part of the cortex itself is clipped (bottom or top) this rating should always result in a fail.
 
+   ![image](figures/Clipping.png)
+
 4) **EPI signal dropout**
 
    Large signal dropout in the EPI image but not in the T1, which should always result in a Fail.
+
+   ![image](figures/Signal_dropout.png)
 
 ---
 
@@ -52,17 +62,25 @@ Reference screenshots are not bundled in this repository; use the criteria below
 
    The brain mask creates a clear outline of the brain, with no significant deviations. Ensure to scroll through each of the sections, ensuring that the brain mask has correctly registered to the brain’s shape at each slice.
 
+   ![image](figures/qsiprep_brainmask.png)
+
 2) **DWI sampling Scheme**
 
-   Compare the two images by rotating the images around and ensuring that they both generally make out the shape of a ball.
+   Compare the two images by rotating the images around and ensuring that they both generally make out the shape of a ball as seen below.
+
+   ![image](figures/qsiprep_qspace.png)
 
 3) **b=0 to anatomical reference registration**
 
    This image represents the final output of the pipeline after motion correction, denoising, and bias field correction. It should be the first image checked for potential issues in earlier steps, such as excessive distortion, signal loss, or cropping. In a good-quality result, the image should clearly resemble brain anatomy with little to no visible artifacts outside the brain.
 
+   ![image](figures/qsiprep_motion.png)
+
 4) **DWI summary**
 
    In the FD plot, look for large or frequent spikes, which indicate sudden head movements during the scan. Consistently high FD values or many volumes above common thresholds (e.g., ~0.5 mm) suggest excessive motion and reduced data quality.
+
+   ![image](figures/qsiprep_FD.png)
 
 ---
 
@@ -72,12 +90,24 @@ Reference screenshots are not bundled in this repository; use the criteria below
 
 1) Make sure there is no black images, which happens if recon-all failed very early in the pipeline.
 
+   ![image](figures/ciftify_1.png)
+
 2) **Aparc image (examples of QC fails)**
 
-   - Check the quality of image. For a very poor quality anatomical, the surface will look shrivelled up.
+   - Check the quality of image. For a very poor quality anatomical, the surface will look shrivelled up like the example below.
+
+     ![image](figures/ciftify_2.png)
+
    - If the gray matter is missing part of the occipital lobe, the back of the brain will look split apart on the bottom view (far right).
-   - For some participants, the surface reconstruction in the aparc view looks jagged (especially in the orbital frontal cortex).
+
+     ![image](figures/ciftify_3.png)
+
+   - For this participant, the surface reconstruction in the aparc view looks jagged (especially in the orbital frontal cortex).
+
+     ![image](figures/ciftify_4.png)
 
 3) **White and pial surfaces**
 
-   A key place to look are the two temporal poles. Surface reconstruction in these areas can fail.
+   A key place to look are the two temporal poles. Surface reconstruction in these area can fail. Here is an example:
+
+   ![image](figures/ciftify_5.png)

--- a/QC_guide.md
+++ b/QC_guide.md
@@ -2,6 +2,8 @@
 
 Here are guidelines to QC each pipeline results.
 
+Reference screenshots are not bundled in this repository; use the criteria below when reviewing HTML reports and figures under `data/local/derivatives/`.
+
 ---
 
 ## fmriprep
@@ -14,13 +16,9 @@ Here are guidelines to QC each pipeline results.
    - Red outline (skullstrip) doesn’t include skull, outlines the brain  
    - Blue outline traces white matter area (lighter parts of brain)
 
-   ![image](figures/Good_BET.png)
-
 2) **Good MNI wrap**
    - “Participant” brain only includes brain (no skull being included)  
    - Make sure that the brain isn’t being stretched down into the cerebellum (indicative of BET segmentation issue)
-
-   ![image](figures/Good_MNI.png)
 
 ---
 
@@ -32,25 +30,17 @@ Here are guidelines to QC each pipeline results.
    - The red/blue outlines should align with the functional image (darker/fuzzier image)  
    - Bright white parts of the functional image should be mostly excluded from the red/blue outline
 
-   ![image](figures/EPI_to_T1.png)
-
 2) **Good SDC correction**
 
-   The “After” Image should more closely align with the blue outline than the “Before” image.
-
-   ![image](figures/SDC_correction.png)
+   The “After” image should more closely align with the blue outline than the “Before” image.
 
 3) **Clipping**
 
    In some cases the bottom part of the cerebellum gets clipped, this is acceptable (a pass) but should still be annotated as having a Clipping issue. However, if any part of the cortex itself is clipped (bottom or top) this rating should always result in a fail.
 
-   ![image](figures/Clipping.png)
-
 4) **EPI signal dropout**
 
    Large signal dropout in the EPI image but not in the T1, which should always result in a Fail.
-
-   ![image](figures/Signal_dropout.png)
 
 ---
 
@@ -62,25 +52,17 @@ Here are guidelines to QC each pipeline results.
 
    The brain mask creates a clear outline of the brain, with no significant deviations. Ensure to scroll through each of the sections, ensuring that the brain mask has correctly registered to the brain’s shape at each slice.
 
-   ![image](figures/qsiprep_brainmask.png)
-
 2) **DWI sampling Scheme**
 
-   Compare the two images by rotating the images around and ensuring that they both generally make out the shape of a ball as seen below.
-
-   ![image](figures/qsiprep_qspace.png)
+   Compare the two images by rotating the images around and ensuring that they both generally make out the shape of a ball.
 
 3) **b=0 to anatomical reference registration**
 
    This image represents the final output of the pipeline after motion correction, denoising, and bias field correction. It should be the first image checked for potential issues in earlier steps, such as excessive distortion, signal loss, or cropping. In a good-quality result, the image should clearly resemble brain anatomy with little to no visible artifacts outside the brain.
 
-   ![image](figures/qsiprep_motion.png)
-
 4) **DWI summary**
 
    In the FD plot, look for large or frequent spikes, which indicate sudden head movements during the scan. Consistently high FD values or many volumes above common thresholds (e.g., ~0.5 mm) suggest excessive motion and reduced data quality.
-
-   ![image](figures/qsiprep_FD.png)
 
 ---
 
@@ -90,24 +72,12 @@ Here are guidelines to QC each pipeline results.
 
 1) Make sure there is no black images, which happens if recon-all failed very early in the pipeline.
 
-   ![image](figures/ciftify_1.png)
-
 2) **Aparc image (examples of QC fails)**
 
-   - Check the quality of image. For a very poor quality anatomical, the surface will look shrivelled up like the example below.
-
-     ![image](figures/ciftify_2.png)
-
+   - Check the quality of image. For a very poor quality anatomical, the surface will look shrivelled up.
    - If the gray matter is missing part of the occipital lobe, the back of the brain will look split apart on the bottom view (far right).
-
-     ![image](figures/ciftify_3.png)
-
-   - For this participant, the surface reconstruction in the aparc view looks jagged (especially in the orbital frontal cortex).
-
-     ![image](figures/ciftify_4.png)
+   - For some participants, the surface reconstruction in the aparc view looks jagged (especially in the orbital frontal cortex).
 
 3) **White and pial surfaces**
 
-   A key place to look are the two temporal poles. Surface reconstruction in these area can fail. Here is an example:
-
-   ![image](figures/ciftify_5.png)
+   A key place to look are the two temporal poles. Surface reconstruction in these areas can fail.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Currently this repo is going to be set up for running things on SciNet Fir clust
 | stage 0|   0a	|  [Setting up the SciNet environment](#Setting-your-scinet-environment-and-prepare-dataset)	| 30 minutes in terminal 	|
 |^ |  0b	|  [Organize your data into BIDS](#organize-your-data-into-bids) 	|   As long as it takes	|
 |^ |  0c	|  [Deface the BIDS data (if not done during step 1)](#deface-the-bids-data-if-not-done-during-step-1) 	|   	|
-|^ |  0d	|  [Move you bids data to the correct place and add lables to participants.tsv file](#Put-your-bids-data-into-the-datalocal-folder-and-add-lables-to-participantstsv-file)	| depends on time to transfer data to SciNet | 
+|^ |  0d	|  [Move your BIDS data to the correct place and add labels to participants.tsv file](#Put-your-bids-data-into-the-datalocal-folder-and-add-lables-to-participantstsv-file)	| depends on time to transfer data to SciNet | 
 |^ |   0e	|  [Initializing nipoppy trackers](#Initializing-nipoppy-trackers)	| 2 minutes in terminal 	|
 |^ |   0f	|  [Edit fmap files](#1-edit-top-up-fmap-files-only)	| 2 minutes in terminal 	|
 |stage 1|   01a	|  [Run MRIQC](#Running-mriqc) 	|  8 hours on slurm 	|
@@ -724,9 +724,11 @@ To change the segmentation to **cerebellum, amygdala, or another region**:
 1. Remove existing labels:  
    ```bash
    rm data/local/derivatives/MAGeTbrain/magetbrain_data/input/atlases/labels/*
+   ```
 2. Copy the desired labels from the shared directory:
    ```bash
    cp /scratch/arisvoin/shared/templateflow/atlases_all4/labels/* data/local/derivatives/MAGeTbrain/magetbrain_data/input/atlases/labels/
+   ```
 
 ### Run the pipeline:
 ```sh
@@ -742,7 +744,7 @@ sbatch  ./code/01_magetbrain_init_scinet.sh
 
 Note -  the script enclosed uses some interesting extra options:
  - it defaults to running all the fmri tasks - the `--task-id` flag can be used to filter from there
- - it is running `synthetic distortion` correction by default - instead of trying to work with the datasets available fieldmaps - because fieldmaps correction can go wrong - but this does require that the phase encoding direction is specificed in the json files (for example `"PhaseEncodingDirection": "j-"`).
+ - it is running `synthetic distortion` correction by default - instead of trying to work with the datasets available fieldmaps - because fieldmaps correction can go wrong - but this does require that the phase encoding direction is specified in the json files (for example `"PhaseEncodingDirection": "j-"`).
 
 ```sh
 ## go to the repo and pull new changes

--- a/code/00_nipoppy_trackers.sh
+++ b/code/00_nipoppy_trackers.sh
@@ -17,7 +17,9 @@ if [ ! -f "${tsv_f}" ]; then
     echo 'participant_id' > "${tsv_f}"
 fi
 
-echo '{ "Name": "ScanD", "BIDSVersion": "1.0.2" }' > "${BASEDIR}/data/local/bids/dataset_description.json"
+if [ ! -f "${BASEDIR}/data/local/bids/dataset_description.json" ]; then
+    echo '{ "Name": "ScanD", "BIDSVersion": "1.0.2" }' > "${BASEDIR}/data/local/bids/dataset_description.json"
+fi
 
 # === Patch TotalReadoutTime into BOLD JSON sidecars (func/ and legacy root paths) ===
 bold_json_found=0

--- a/code/01_fmriprep_fit_scinet.sh
+++ b/code/01_fmriprep_fit_scinet.sh
@@ -33,7 +33,6 @@ module load apptainer/1.3.5
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
 ## these folders envs need to be set up for this script to run properly 
-## see notebooks/00_setting_up_envs.md for the set up instructions
 export FMRIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/fmriprep-25.2.4.simg
 

--- a/code/01_freesurfer_long_scinet.sh
+++ b/code/01_freesurfer_long_scinet.sh
@@ -32,7 +32,6 @@ module load apptainer/1.3.5
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
 ## these folders envs need to be set up for this script to run properly 
-## see notebooks/00_setting_up_envs.md for the set up instructions
 export FMRIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/freesurfer-7.4.1.simg
 

--- a/code/01_mriqc_scinet.sh
+++ b/code/01_mriqc_scinet.sh
@@ -32,7 +32,6 @@ trap "cleanup_ramdisk" TERM
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
 ## these folders envs need to be set up for this script to run properly 
-## see notebooks/00_setting_up_envs.md for the set up instructions
 export FMRIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/mriqc-24.0.0.simg
 

--- a/code/01_qsiprep_scinet.sh
+++ b/code/01_qsiprep_scinet.sh
@@ -32,7 +32,6 @@ module load apptainer/1.3.5
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
 ## these folders envs need to be set up for this script to run properly 
-## see notebooks/00_setting_up_envs.md for the set up instructions
 export QSIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
 
@@ -40,7 +39,7 @@ export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
 # export OUTPUT_DIR=${BASEDIR}/data/local/fmriprep  # use if version of fmriprep >=20.2
 export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0 # use if version of fmriprep <=20.1
 
-# adding random string (project_id) to BBUFFER folder to prevent conflicts betwwen projects
+# adding random string (project_id) to BBUFFER folder to prevent conflicts between projects
 export WORK_DIR=${SLURM_TMPDIR}/SCanD/qsiprep
 export LOGS_DIR=${BASEDIR}/logs
 mkdir -vp ${OUTPUT_DIR} ${WORK_DIR} # ${LOCAL_FREESURFER_DIR}

--- a/code/01_smriprep_scinet.sh
+++ b/code/01_smriprep_scinet.sh
@@ -34,7 +34,6 @@ trap "cleanup_ramdisk" TERM
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
 ## these folders envs need to be set up for this script to run properly 
-## see notebooks/00_setting_up_envs.md for the set up instructions
 export SMRIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/fmriprep-25.2.4.simg
 

--- a/code/02_fmriprep_apply_scinet.sh
+++ b/code/02_fmriprep_apply_scinet.sh
@@ -32,7 +32,6 @@ module load apptainer/1.3.5
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
 ## these folders envs need to be set up for this script to run properly 
-## see notebooks/00_setting_up_envs.md for the set up instructions
 export FMRIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/fmriprep-25.2.4.simg
 

--- a/code/02_qsirecon_FSL_scinet.sh
+++ b/code/02_qsirecon_FSL_scinet.sh
@@ -32,7 +32,6 @@ module load apptainer/1.3.5
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
 ## these folders envs need to be set up for this script to run properly 
-## see notebooks/00_setting_up_envs.md for the set up instructions
 export QSIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
 

--- a/code/02_tractography_multi_scinet.sh
+++ b/code/02_tractography_multi_scinet.sh
@@ -32,7 +32,6 @@ module load apptainer/1.3.5
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
 ## these folders envs need to be set up for this script to run properly 
-## see notebooks/00_setting_up_envs.md for the set up instructions
 export QSIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
 

--- a/code/02_tractography_single_scinet.sh
+++ b/code/02_tractography_single_scinet.sh
@@ -32,7 +32,6 @@ module load apptainer/1.3.5
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
 ## these folders envs need to be set up for this script to run properly 
-## see notebooks/00_setting_up_envs.md for the set up instructions
 export QSIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
 

--- a/code/03_glm_surface_scinet.sh
+++ b/code/03_glm_surface_scinet.sh
@@ -32,24 +32,18 @@ export SING_CONTAINER=${BASEDIR}/containers/glm-0.0.1.sif
 
 if [ -z "$1" ]; then
     echo "ERROR: No model file specified. Pass the absolute path to your task-specific model JSON as the first argument."
-    echo "  sbatch --array=0-\${array_job_length} code/03_glm_surface_scinet.sh \$PWD/code/glm/examples/models/your-model.json"
+    echo "  source ./code/lib/slurm_array.sh"
+    echo "  scand_submit_participant_array ./code/03_glm_surface_scinet.sh 1 \"\$PWD/code/glm/examples/models/your-model.json\""
     exit 1
 fi
 export MODEL=$1
 
 mkdir -p $OUT_DIR
 
-# Parsing subject
-# start=$(($SLURM_ARRAY_TASK_ID * SUB_SIZE + 1))
-# end=$((start + SUB_SIZE - 1))
-
-# SUBJECTS=$(sed -n -E "s/sub-(\S*).*/\1/p" ${BIDS_DIR}/participants.tsv \
-#     | sed -n "${start},${end}p")
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
-# N_SUBJECTS=$(( $( wc -l ${BIDS_DIR}/participants.tsv | cut -f1 -d' ' ) - 1 ))
-N_SUBJECTS=$(grep -c '^sub-' ./data/local/bids/participants.tsv)
-array_job_length=$(( N_SUBJECTS - 1))
-# array_job_length=$(echo "$N_SUBJECTS/${SUB_SIZE}" | bc)
+
+N_SUBJECTS=$(( $( wc -l ${BIDS_DIR}/participants.tsv | cut -f1 -d' ' ) - 1 ))
+array_job_length=$(echo "$N_SUBJECTS/${SUB_SIZE}" | bc)
 Tail=$((N_SUBJECTS-(array_job_length*SUB_SIZE)))
 
 if [ "$SLURM_ARRAY_TASK_ID" -eq "$array_job_length" ]; then

--- a/code/06_extract_to_share_slurm.sh
+++ b/code/06_extract_to_share_slurm.sh
@@ -428,9 +428,20 @@ if [ -n "$latest_status" ]; then
 else
     echo "WARNING: No Neurobagel processing_status file found; skipping copy to data/share."
 fi
-cp "$(ls -t ${BASEDIR}/Neurobagel/.manifests/manifest*.tsv | head -n 1)" data/share/manifest.tsv
-cp ${BASEDIR}/Neurobagel/derivatives/processing_status_fmriprep.tsv  ${BASEDIR}/data/share
-cp ${BASEDIR}/Neurobagel/derivatives/processing_status_qsiprep.tsv  ${BASEDIR}/data/share
+latest_manifest="$(ls -t ${BASEDIR}/Neurobagel/.manifests/manifest*.tsv 2>/dev/null | head -n 1)"
+if [ -n "$latest_manifest" ]; then
+    cp "$latest_manifest" data/share/manifest.tsv
+else
+    echo "WARNING: No Neurobagel manifest file found; skipping copy to data/share."
+fi
+
+for sidecar in processing_status_fmriprep.tsv processing_status_qsiprep.tsv; do
+    if [ -f "${BASEDIR}/Neurobagel/derivatives/${sidecar}" ]; then
+        cp "${BASEDIR}/Neurobagel/derivatives/${sidecar}" "${BASEDIR}/data/share/"
+    else
+        echo "WARNING: Missing Neurobagel/derivatives/${sidecar}; skipping."
+    fi
+done
 
 cp ${BASEDIR}/data/local/bids/participants.tsv ${BASEDIR}/data/share
 
@@ -438,16 +449,12 @@ cp ${BASEDIR}/data/local/bids/participants.tsv ${BASEDIR}/data/share
 GLM_SHARE_DIR=${BASEDIR}/data/share/glm/0.0.1
 GLM_LOCAL_DIR=${BASEDIR}/data/local/derivatives/glm/0.0.1
 mkdir -p ${GLM_SHARE_DIR}
-if [ -d "$GLM_LOCAL_DIR" ];
-then
+if [ -d "$GLM_LOCAL_DIR" ]; then
     echo "Copying GLM outputs, metadata, and QC images"
-    # Copying the metadata json
-    subjects=`cd ${GLM_LOCAL_DIR}; ls -1d sub-*`
-    
-    echo "for subject in ${subjects}; do
+    for subject in $(cd "${GLM_LOCAL_DIR}" && ls -1d sub-* 2>/dev/null); do
         GLM_SUB_SHARE_DIR=${GLM_SHARE_DIR}/${subject}
         GLM_SUB_LOCAL_DIR=${GLM_LOCAL_DIR}/${subject}
-        mkdir -p ${GLM_SUB_SHARE_DIR}
+        mkdir -p "${GLM_SUB_SHARE_DIR}"
         rsync -zarv ${GLM_SUB_LOCAL_DIR}/*glm.json ${GLM_SUB_SHARE_DIR}/
         rsync -zarv ${GLM_SUB_LOCAL_DIR}/*design.svg ${GLM_SUB_SHARE_DIR}/
         rsync -zarv ${GLM_SUB_LOCAL_DIR}/*design.tsv ${GLM_SUB_SHARE_DIR}/
@@ -456,13 +463,12 @@ then
         rsync -zarv ${GLM_SUB_LOCAL_DIR}/*residuals.dtseries.nii ${GLM_SUB_SHARE_DIR}/
 
         if compgen -G "${GLM_SUB_LOCAL_DIR}/*fixedeffects.json" > /dev/null; then
-        echo "Copying fixed-effect outputs"
-        rsync -zarv ${GLM_SUB_LOCAL_DIR}/*fixedeffects.json ${GLM_SUB_SHARE_DIR}/
-        rsync -zarv ${GLM_SUB_LOCAL_DIR}/*fixed*.dscalar.nii ${GLM_SUB_SHARE_DIR}/
-        rsync -zarv ${GLM_SUB_LOCAL_DIR}/*fixed*.png ${GLM_SUB_SHARE_DIR}/
+            echo "Copying fixed-effect outputs for ${subject}"
+            rsync -zarv ${GLM_SUB_LOCAL_DIR}/*fixedeffects.json ${GLM_SUB_SHARE_DIR}/
+            rsync -zarv ${GLM_SUB_LOCAL_DIR}/*fixed*.dscalar.nii ${GLM_SUB_SHARE_DIR}/
+            rsync -zarv ${GLM_SUB_LOCAL_DIR}/*fixed*.png ${GLM_SUB_SHARE_DIR}/
         fi
     done
 else
     echo "GLM outputs not found."
 fi
-"

--- a/code/trackers.sh
+++ b/code/trackers.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
-BASEDIR=$PWD
+# Manual nipoppy tracker re-run utility (development/debug).
+# Run from the SCanD project root:
+#   cd ${SCRATCH}/SCanD_project && bash code/trackers.sh
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASEDIR="${SCRIPT_DIR}/.."
+cd "$BASEDIR" || exit 1
+
 module load apptainer/1.3.5
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -27,7 +33,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -47,7 +52,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -63,7 +67,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -83,7 +86,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
     
@@ -104,7 +106,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -144,7 +145,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -167,7 +167,6 @@ python "$BASEDIR/code/fmriprep_method_tsv.py" \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
     
@@ -250,7 +249,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -269,7 +267,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -328,7 +325,6 @@ singularity exec \
 singularity exec \
   	--env BASEDIR="$BASEDIR" \
     --bind $BASEDIR:$BASEDIR \
-  	--env SUBJECTS="$SUBJECTS" \
   	${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     	set -euo pipefail
 
@@ -351,7 +347,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -392,7 +387,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -410,7 +404,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS="$SUBJECTS" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 

--- a/share_folder.md
+++ b/share_folder.md
@@ -23,6 +23,8 @@ ${BASEDIR}/data/share
 │   └── files for each subject
 ├── fmriprep/25.2.4
 │   └── QC images and metadata for each scan
+├── glm/0.0.1
+│   └── GLM model outputs, contrasts, and QC images per subject
 ├── freesurfer_group
 │   ├── group-level FreeSurfer metrics (aseg, euler, aparc thickness)
 │   ├── Schaefer2018 parcellation metrics (100–1000 parcels: thickness, surfacearea, grayvol)
@@ -39,7 +41,10 @@ ${BASEDIR}/data/share
 ├── noddireg
 │   └── .tsv file: parcel-wise summary statistics of NODDI microstructural metrics
 ├── participants.tsv
+├── manifest.tsv
 ├── processing_status.tsv
+├── processing_status_fmriprep.tsv
+├── processing_status_qsiprep.tsv
 ├── qsiprep/0.22.0
 │   ├── qsiprep_metrics.csv
 │   └── QC images and metadata for each scan

--- a/stage_2.sh
+++ b/stage_2.sh
@@ -53,9 +53,9 @@ if [[ "$run_ciftify" =~ ^(yes|y)$ ]]; then
     if [[ "$N_SUBJECTS" -eq 0 ]]; then
         echo "No subject folders found in ${SUBJECTS_DIR}. Skipping ciftify_anat."
     else
-        ARRAY_JOB_LENGTH=$((N_SUBJECTS - 1))
-        echo "Submitting ciftify_anat job array with indices 0 to ${ARRAY_JOB_LENGTH}"
-        sbatch --array=0-${ARRAY_JOB_LENGTH} ./code/02_ciftify_anat_scinet.sh
+        max_task=$(scand_slurm_array_max "$N_SUBJECTS" 1)
+        echo "Submitting ciftify_anat job array with indices 0 to ${max_task}"
+        sbatch --array=0-${max_task} ./code/02_ciftify_anat_scinet.sh
     fi
 else
     echo "Skipping ciftify_anat."


### PR DESCRIPTION
Execute GLM rsync loop in extract_to_share_slurm, guard manifest and sidecar copies, preserve dataset_description on re-init, align ciftify/GLM array logic, remove stale notebook refs, and update QC/share docs.