### PR TITLE
Fix share paths, Fir terminal extract, trackers env, and doc typos.

### DIFF
--- a/Quick_start_workflow_automation.md
+++ b/Quick_start_workflow_automation.md
@@ -19,7 +19,7 @@ git pull         #in case you need to pull new code
 source ./stage_1.sh
 ```
 
-## stage 2 (ciftify_anat, fmriprep_apply, freesurfer_parcellate, magetbrain_register, qsireconfsl, amico_noddi, tractography):
+## stage 2 (ciftify_anat, fmriprep_apply, freesurfer_parcellate, magetbrain_register, qsirecon_FSL, amico_noddi, tractography):
 ```sh
 ## go to the repo and pull new changes
 cd ${SCRATCH}/SCanD_project

--- a/README.md
+++ b/README.md
@@ -51,22 +51,22 @@ ${BASEDIR}
 │       ├── qsiprep              # contains only qc images and metadata
 │       ├── smriprep             # contains only qc images and metadata
 │       ├── tractify             # contains connectivity.mat file
-│       ├── xcp-d                # contains xcp results with GSR
+│       ├── xcp_d                # contains xcp results with GSR
 │       └── xcp_noGSR            # contains xcp results with GSR              
-|── LICENSE
+├── LICENSE
 ├── logs               # logs from jobs run on cluster           
-|── Neurobagel
-|── project_id
-|── QC_guide.md
-|── Quick_start_workflow automation.md
-|── README.md
-|── share_folder.md
-|──stage_1.sh
-|──stage_2.sh
-|──stage_3.sh
-|──stage_4.sh
-|──stage_5.sh
-|──stage_6.sh
+├── Neurobagel
+├── project_id
+├── QC_guide.md
+├── Quick_start_workflow_automation.md
+├── README.md
+├── share_folder.md
+├── stage_1.sh
+├── stage_2.sh
+├── stage_3.sh
+├── stage_4.sh
+├── stage_5.sh
+├── stage_6.sh
 └── templates                  # an extra folder with pre-downloaded fmriprep templates (see setup section)
     └── parcellations
         ├── README.md
@@ -691,7 +691,7 @@ After QSIPrep completes, a per-pipeline sidecar with the distortion-correction m
 
 This file is updated by the QSIPrep nipoppy tracker block (not the main Neurobagel status under `.processing_statuses/`). It contains:
 - participant_id
-- qsiprep_method
+- qsiprep_sdc_method
 
 ## Running smriprep
 If you want to only run structural data, you will need this pipeline. Otherwise, skip this pipeline.

--- a/code/00_setup_data_directories.sh
+++ b/code/00_setup_data_directories.sh
@@ -43,7 +43,7 @@ ln -s ${CONTAINER_DIR}/nipoppy.sif  containers/nipoppy.sif
 
 
 ## copy freesurfer licence
-cp /scratch//arisvoin/shared/fs_license/license.txt templates/.freesurfer.txt
+cp /scratch/arisvoin/shared/fs_license/license.txt templates/.freesurfer.txt
 
 
 ## copy templates

--- a/code/06_extract_to_share_slurm.sh
+++ b/code/06_extract_to_share_slurm.sh
@@ -424,13 +424,13 @@ fi
 # sharing nipoppy trackers
 latest_status="$(ls -t ${BASEDIR}/Neurobagel/derivatives/.processing_statuses/processing_status-*.tsv 2>/dev/null | head -n 1)"
 if [ -n "$latest_status" ]; then
-    cp "$latest_status" data/share/processing_status.tsv
+    cp "$latest_status" "${BASEDIR}/data/share/processing_status.tsv"
 else
     echo "WARNING: No Neurobagel processing_status file found; skipping copy to data/share."
 fi
 latest_manifest="$(ls -t ${BASEDIR}/Neurobagel/.manifests/manifest*.tsv 2>/dev/null | head -n 1)"
 if [ -n "$latest_manifest" ]; then
-    cp "$latest_manifest" data/share/manifest.tsv
+    cp "$latest_manifest" "${BASEDIR}/data/share/manifest.tsv"
 else
     echo "WARNING: No Neurobagel manifest file found; skipping copy to data/share."
 fi

--- a/code/ENIGMA_ExtractCortical.sh
+++ b/code/ENIGMA_ExtractCortical.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
+# ENIGMA consortium cortical/subcortical tables (Desikan-Killiany aparc stats).
+# Schaefer parcellation group tables are merged separately under 00_group2_stats_tables/.
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 BASEDIR=${SCRIPT_DIR}/..
 
 SUBJECTS_DIR=${BASEDIR}/data/local/derivatives/freesurfer/7.4.1
 PREFIX=sub-
 
-mkdir ${BASEDIR}/data/local/derivatives/freesurfer/7.4.1/ENIGMA_extract
+mkdir -p ${BASEDIR}/data/local/derivatives/freesurfer/7.4.1/ENIGMA_extract
 
 
 echo 'SubjID,L_bankssts_thickavg,L_caudalanteriorcingulate_thickavg,L_caudalmiddlefrontal_thickavg,L_cuneus_thickavg,L_entorhinal_thickavg,L_fusiform_thickavg,L_inferiorparietal_thickavg,L_inferiortemporal_thickavg,L_isthmuscingulate_thickavg,L_lateraloccipital_thickavg,L_lateralorbitofrontal_thickavg,L_lingual_thickavg,L_medialorbitofrontal_thickavg,L_middletemporal_thickavg,L_parahippocampal_thickavg,L_paracentral_thickavg,L_parsopercularis_thickavg,L_parsorbitalis_thickavg,L_parstriangularis_thickavg,L_pericalcarine_thickavg,L_postcentral_thickavg,L_posteriorcingulate_thickavg,L_precentral_thickavg,L_precuneus_thickavg,L_rostralanteriorcingulate_thickavg,L_rostralmiddlefrontal_thickavg,L_superiorfrontal_thickavg,L_superiorparietal_thickavg,L_superiortemporal_thickavg,L_supramarginal_thickavg,L_frontalpole_thickavg,L_temporalpole_thickavg,L_transversetemporal_thickavg,L_insula_thickavg,R_bankssts_thickavg,R_caudalanteriorcingulate_thickavg,R_caudalmiddlefrontal_thickavg,R_cuneus_thickavg,R_entorhinal_thickavg,R_fusiform_thickavg,R_inferiorparietal_thickavg,R_inferiortemporal_thickavg,R_isthmuscingulate_thickavg,R_lateraloccipital_thickavg,R_lateralorbitofrontal_thickavg,R_lingual_thickavg,R_medialorbitofrontal_thickavg,R_middletemporal_thickavg,R_parahippocampal_thickavg,R_paracentral_thickavg,R_parsopercularis_thickavg,R_parsorbitalis_thickavg,R_parstriangularis_thickavg,R_pericalcarine_thickavg,R_postcentral_thickavg,R_posteriorcingulate_thickavg,R_precentral_thickavg,R_precuneus_thickavg,R_rostralanteriorcingulate_thickavg,R_rostralmiddlefrontal_thickavg,R_superiorfrontal_thickavg,R_superiorparietal_thickavg,R_superiortemporal_thickavg,R_supramarginal_thickavg,R_frontalpole_thickavg,R_temporalpole_thickavg,R_transversetemporal_thickavg,R_insula_thickavg,LThickness,RThickness,LSurfArea,RSurfArea,ICV' > ${BASEDIR}/data/local/derivatives/freesurfer/7.4.1/ENIGMA_extract/CorticalMeasuresENIGMA_ThickAvg.csv
@@ -13,8 +15,9 @@ echo 'SubjID,L_bankssts_surfavg,L_caudalanteriorcingulate_surfavg,L_caudalmiddle
 
 for subj_id in `ls -d ${SUBJECTS_DIR}/${PREFIX}*`; do #may need to change this so that it selects subjects with FS output
 
-  printf "%s,"  "${subj_id}" >> ${BASEDIR}/data/local/derivatives/freesurfer/7.4.1/ENIGMA_extract/CorticalMeasuresENIGMA_ThickAvg.csv
-  printf "%s,"  "${subj_id}" >> ${BASEDIR}/data/local/derivatives/freesurfer/7.4.1/ENIGMA_extract/CorticalMeasuresENIGMA_SurfAvg.csv
+  subj_label=$(basename "${subj_id}")
+  printf "%s,"  "${subj_label}" >> ${BASEDIR}/data/local/derivatives/freesurfer/7.4.1/ENIGMA_extract/CorticalMeasuresENIGMA_ThickAvg.csv
+  printf "%s,"  "${subj_label}" >> ${BASEDIR}/data/local/derivatives/freesurfer/7.4.1/ENIGMA_extract/CorticalMeasuresENIGMA_SurfAvg.csv
 
   for side in lh.aparc.stats rh.aparc.stats; do
 
@@ -50,7 +53,8 @@ echo "SubjID, LLatVent,RLatVent,Lthal,Rthal,Lcaud,Rcaud,Lput,Rput,\
 for subj_id in `ls -d ${SUBJECTS_DIR}/${PREFIX}*`;
 do #may need to change this so that is selects subjects with FS output
 
-  printf "%s,"  "${subj_id}" >> ${BASEDIR}/data/local/derivatives/freesurfer/7.4.1/ENIGMA_extract/LandRvolumes.csv
+  subj_label=$(basename "${subj_id}")
+  printf "%s,"  "${subj_label}" >> ${BASEDIR}/data/local/derivatives/freesurfer/7.4.1/ENIGMA_extract/LandRvolumes.csv
 
   for x in Left-Lateral-Ventricle Right-Lateral-Ventricle Left-Thalamus-Proper Right-Thalamus-Proper Left-Caudate Right-Caudate Left-Putamen Right-Putamen Left-Pallidum Right-Pallidum Left-Hippocampus Right-Hippocampus Left-Amygdala Right-Amygdala Left-Accumbens-area Right-Accumbens-area;
   do

--- a/code/extract_to_share_stage3_terminal.sh
+++ b/code/extract_to_share_stage3_terminal.sh
@@ -1,11 +1,44 @@
 #!/bin/bash
-## magetbrain, gen_qsiprep_motion_metrics.py (Fir-compatible; mirrors 06_extract_to_share_terminal.sh)
+## magetbrain, gen_qsiprep_motion_metrics.py
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 BASEDIR=${SCRIPT_DIR}/..
 
+
 module load apptainer/1.3.5
 
+echo "Running qsiprep_metrics.csv"
+
+## Generate qsiprep motion metrics and magetbrain
+module load NiaEnv/2019b python/3.6.8
+
+# Create a directory for virtual environments if it doesn't exist
+mkdir ${BASEDIR}/../.virtualenvs
+cd ${BASEDIR}/../.virtualenvs
+virtualenv --system-site-packages ${BASEDIR}/../.virtualenvs/myenv
+
+# Activate the virtual environment
+source ${BASEDIR}/../.virtualenvs/myenv/bin/activate
+
+cd ${BASEDIR}
+python3 ${BASEDIR}/code/gen_qsiprep_motion_metrics.py
+
+
+if [ -f "${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep/qsiprep_metrics.csv" ];
+then
+
+echo "copying over qsiprep_metrics.csv"
+rsync -a ${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep/qsiprep_metrics.csv ${BASEDIR}/data/share/qsiprep/0.22.0/
+
+else
+
+    echo "No qsiprep_metrics.csv found."
+
+fi
+
+
 # sharing magetbrain outputs
+echo "Running magetbrain QC step"
+
 mkdir -p ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC
 singularity exec --cleanenv -B ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data:/data ${BASEDIR}/containers/magetbrain.sif /bin/bash -c "export LANG=C.UTF-8 && export LC_ALL=C.UTF-8 && export LD_LIBRARY_PATH=/opt/minc/1.9.18/lib:\$LD_LIBRARY_PATH && collect_volumes.sh /data/output/fusion/majority_vote/*.mnc > /data/QC/volumes.csv"
 source ${BASEDIR}/code/magetbrain_QC.sh
@@ -13,30 +46,16 @@ source ${BASEDIR}/code/magetbrain_QC.sh
 mkdir -p ${BASEDIR}/data/share/magetbrain/input
 mkdir -p ${BASEDIR}/data/share/magetbrain/fusion
 
-if [ -d "${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC" ]; then
-    rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/output/fusion/majority_vote/*labels.mnc ${BASEDIR}/data/share/magetbrain/fusion
-    rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/input/subjects/brains/*.mnc* ${BASEDIR}/data/share/magetbrain/input
-    rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC ${BASEDIR}/data/share/magetbrain/
+
+if [ -d "${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC" ];
+then
+
+rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/output/fusion/majority_vote/*labels.mnc ${BASEDIR}/data/share/magetbrain/fusion
+rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/input/subjects/brains/*.mnc* ${BASEDIR}/data/share/magetbrain/input
+rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC ${BASEDIR}/data/share/magetbrain/
+
 else
+
     echo "No magetbrain QC folder found."
-fi
 
-## Generate qsiprep motion metrics
-module load python/3.10
-
-mkdir -p ${BASEDIR}/../.virtualenvs
-cd ${BASEDIR}/../.virtualenvs
-virtualenv --system-site-packages ${BASEDIR}/../.virtualenvs/myenv
-
-source ${BASEDIR}/../.virtualenvs/myenv/bin/activate
-
-cd ${BASEDIR}
-python3 ${BASEDIR}/code/gen_qsiprep_motion_metrics.py
-
-if [ -f "${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep/qsiprep_metrics.csv" ]; then
-    echo "copying over qsiprep_metrics.csv"
-    mkdir -p ${BASEDIR}/data/share/qsiprep/0.22.0/
-    rsync -a ${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep/qsiprep_metrics.csv ${BASEDIR}/data/share/qsiprep/0.22.0/
-else
-    echo "No qsiprep_metrics.csv found."
 fi

--- a/code/extract_to_share_stage3_terminal.sh
+++ b/code/extract_to_share_stage3_terminal.sh
@@ -1,44 +1,11 @@
 #!/bin/bash
-## magetbrain, gen_qsiprep_motion_metrics.py
+## magetbrain, gen_qsiprep_motion_metrics.py (Fir-compatible; mirrors 06_extract_to_share_terminal.sh)
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 BASEDIR=${SCRIPT_DIR}/..
 
-
 module load apptainer/1.3.5
 
-echo "Running qsiprep_metrics.csv"
-
-## Generate qsiprep motion metrics and magetbrain
-module load NiaEnv/2019b python/3.6.8
-
-# Create a directory for virtual environments if it doesn't exist
-mkdir ${BASEDIR}/../.virtualenvs
-cd ${BASEDIR}/../.virtualenvs
-virtualenv --system-site-packages ${BASEDIR}/../.virtualenvs/myenv
-
-# Activate the virtual environment
-source ${BASEDIR}/../.virtualenvs/myenv/bin/activate
-
-cd ${BASEDIR}
-python3 ${BASEDIR}/code/gen_qsiprep_motion_metrics.py
-
-
-if [ -f "${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep/qsiprep_metrics.csv" ];
-then
-
-echo "copying over qsiprep_metrics.csv"
-rsync -a ${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep/qsiprep_metrics.csv ${BASEDIR}/data/share/qsiprep/0.22.0/
-
-else
-
-    echo "No qsiprep_metrics.csv found."
-
-fi
-
-
 # sharing magetbrain outputs
-echo "Running magetbrain QC step"
-
 mkdir -p ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC
 singularity exec --cleanenv -B ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data:/data ${BASEDIR}/containers/magetbrain.sif /bin/bash -c "export LANG=C.UTF-8 && export LC_ALL=C.UTF-8 && export LD_LIBRARY_PATH=/opt/minc/1.9.18/lib:\$LD_LIBRARY_PATH && collect_volumes.sh /data/output/fusion/majority_vote/*.mnc > /data/QC/volumes.csv"
 source ${BASEDIR}/code/magetbrain_QC.sh
@@ -46,16 +13,30 @@ source ${BASEDIR}/code/magetbrain_QC.sh
 mkdir -p ${BASEDIR}/data/share/magetbrain/input
 mkdir -p ${BASEDIR}/data/share/magetbrain/fusion
 
-
-if [ -d "${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC" ];
-then
-
-rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/output/fusion/majority_vote/*labels.mnc ${BASEDIR}/data/share/magetbrain/fusion
-rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/input/subjects/brains/*.mnc* ${BASEDIR}/data/share/magetbrain/input
-rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC ${BASEDIR}/data/share/magetbrain/
-
+if [ -d "${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC" ]; then
+    rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/output/fusion/majority_vote/*labels.mnc ${BASEDIR}/data/share/magetbrain/fusion
+    rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/input/subjects/brains/*.mnc* ${BASEDIR}/data/share/magetbrain/input
+    rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC ${BASEDIR}/data/share/magetbrain/
 else
-
     echo "No magetbrain QC folder found."
+fi
 
+## Generate qsiprep motion metrics
+module load python/3.10
+
+mkdir -p ${BASEDIR}/../.virtualenvs
+cd ${BASEDIR}/../.virtualenvs
+virtualenv --system-site-packages ${BASEDIR}/../.virtualenvs/myenv
+
+source ${BASEDIR}/../.virtualenvs/myenv/bin/activate
+
+cd ${BASEDIR}
+python3 ${BASEDIR}/code/gen_qsiprep_motion_metrics.py
+
+if [ -f "${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep/qsiprep_metrics.csv" ]; then
+    echo "copying over qsiprep_metrics.csv"
+    mkdir -p ${BASEDIR}/data/share/qsiprep/0.22.0/
+    rsync -a ${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep/qsiprep_metrics.csv ${BASEDIR}/data/share/qsiprep/0.22.0/
+else
+    echo "No qsiprep_metrics.csv found."
 fi

--- a/code/trackers.sh
+++ b/code/trackers.sh
@@ -208,7 +208,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS_BATCH="$SUBJECTS_BATCH" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
@@ -228,7 +227,6 @@ singularity exec \
 singularity exec \
   --env BASEDIR="$BASEDIR" \
   --bind $BASEDIR:$BASEDIR \
-  --env SUBJECTS_BATCH="$SUBJECTS_BATCH" \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
     

--- a/share_folder.md
+++ b/share_folder.md
@@ -2,8 +2,6 @@
 
 Here is a checklist for the share folder results.
 
-Stage 6 uses `code/06_extract_to_share_slurm.sh` and `code/06_extract_to_share_terminal.sh`. The `code/extract_to_share_stage*.sh` scripts are legacy stage-split Slurm jobs and are not invoked by `stage_6.sh`.
-
 
 ```
 ${BASEDIR}/data/share

--- a/share_folder.md
+++ b/share_folder.md
@@ -2,6 +2,8 @@
 
 Here is a checklist for the share folder results.
 
+Stage 6 uses `code/06_extract_to_share_slurm.sh` and `code/06_extract_to_share_terminal.sh`. The `code/extract_to_share_stage*.sh` scripts are legacy stage-split Slurm jobs and are not invoked by `stage_6.sh`.
+
 
 ```
 ${BASEDIR}/data/share
@@ -52,7 +54,7 @@ ${BASEDIR}/data/share
 │   └── QC images and metadata for each scan
 ├── tractify
 │   └── connectivity.mat file for each scan         
-├── xcp-d/0.7.3
+├── xcp_d/0.7.3
 │   └── QC images and metadata for each scan
-└── xcp-noGSR
+└── xcp_noGSR
     └── QC images and metadata for each scan

--- a/stage_1.sh
+++ b/stage_1.sh
@@ -27,8 +27,8 @@ run_pipeline() {
 # Prompt user for each pipeline
 run_pipeline "mriqc" "./code/01_mriqc_scinet.sh" 1
 run_pipeline "qsiprep" "./code/01_qsiprep_scinet.sh" 1
-run_pipeline "fmriprep_fit" "code/01_fmriprep_fit_scinet.sh" 1
-run_pipeline "freesurfer" "code/01_freesurfer_long_scinet.sh" 1
+run_pipeline "fmriprep_fit" "./code/01_fmriprep_fit_scinet.sh" 1
+run_pipeline "freesurfer" "./code/01_freesurfer_long_scinet.sh" 1
 run_pipeline "smriprep" "./code/01_smriprep_scinet.sh" 1
 
 # Prompt for magetbrain_init


### PR DESCRIPTION
Use BASEDIR for Neurobagel copies in extract slurm script, align extract_to_share_stage3_terminal with Fir python modules, remove unused SUBJECTS_BATCH from trackers, correct share folder and README naming, stage_1 script paths, setup path typo, ENIGMA SubjID basename, and legacy extract script note.