### PR TITLE
Fix README doc nits and document stage 6 run-together workflow.

### DIFF
--- a/QC_guide.md
+++ b/QC_guide.md
@@ -1,6 +1,6 @@
 # QC Guide
 
-Here are guidelines to QC each pipeline results.
+Here are guidelines to QC each pipeline's results.
 
 ---
 

--- a/Quick_start_workflow_automation.md
+++ b/Quick_start_workflow_automation.md
@@ -55,11 +55,23 @@ source ./stage_5.sh
 
 ## Stage 6 (extract data to share folder)
 
+Submit the Slurm extract job and run the login-node terminal script together (`stage_6.sh` does both in one step).
+
 ```sh
 cd ${SCRATCH}/SCanD_project
 git pull
 
 source ./stage_6.sh
+```
+
+Or run the commands directly:
+
+```sh
+cd ${SCRATCH}/SCanD_project
+git pull
+
+sbatch ./code/06_extract_to_share_slurm.sh
+source ./code/06_extract_to_share_terminal.sh
 ```
 
 ## Consortium handoff

--- a/Quick_start_workflow_automation.md
+++ b/Quick_start_workflow_automation.md
@@ -1,4 +1,4 @@
-# Workflow automation (stage scripts)
+# Workflow automation (stage scripts) 🚀
 
 Use the `stage_*.sh` scripts at the repository root to run pipelines one stage at a time. Each script prompts you for which pipelines to submit, so you can skip diffusion or functional steps when they do not apply to your dataset.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ ${BASEDIR}
 │   ├── nipoppy.sif
 │   ├── noddi_postproc-v.1.0.simg
 │   ├── tbss_2023-10-10.simg
+│   ├── glm-0.0.1.simg
 │   └── xcp_d-0.7.3.simg
 ├── data
 │   ├── local                    # folder for the "local" dataset
@@ -128,7 +129,7 @@ Currently this repo is going to be set up for running things on SciNet Fir clust
 |^ |   04b	|  [Check tsv file](#check-tsv-file) 	|    	|
 |stage 5 |  05a |  [Run extract-noddi](#running-extract-noddi) 	|  ~3 hours on Slurm	|
 |^ |   05b	|  [Check tsv file](#check-tsv-file) 	|    	|
-|stage 6 |   06a	|  [Run extract and share to move to data to sharable folder](#syncing-the-data-to-the-share-directory) 	|   ~8 hours on Slurm (plus terminal steps after the job completes)	|
+|stage 6 |   06a	|  [Extract and share to consortium folder](#syncing-the-data-to-the-share-directory) 	|   ~8 hours on Slurm (Slurm job and login-node terminal script run together)	|
 
 # Setting your SciNet environment and prepare dataset
 
@@ -217,7 +218,7 @@ mkdir bidsbackup_json
 rsync -zarv  --include "*/" --include="*.json" --exclude="*"  data/local/bids  bidsbackup_json
 ```
 
-In some cases dcm2niix conversion fails to add "IntendedFor" in the fmap files which causes errors in fmriprep_apply step. Therefore, we need to edit fmap file in the bids folder and add "intendedFor"s. In order to edit these files we need to run the following python code with a specific configuration depend on each dataset.
+In some cases, dcm2niix conversion fails to add the BIDS ``IntendedFor`` field in fmap JSON files, which causes errors in the fmriprep_apply step. Edit those fieldmaps (or run the script below) using a YAML configuration that matches your dataset naming.
 
 This script automatically fills the ``"IntendedFor"`` field in BIDS fieldmap JSON files. It reads a YAML configuration file that describes your dataset's naming patterns, then links each fieldmap to correct fMRI or DWI files.
 
@@ -555,7 +556,7 @@ The script updates each fieldmap JSON like:
 
 ### Check "IntendedFor" in fieldmap
 
-If your study collected fieldmaps for diffusion data and you plan to use them for distortion correction, you must ensure the ``IntendedFor`` field in your fieldmap files is correctly specified before running stage 1 [Run fMRIPREP Fit](#Running-fmriprep-fit-includes-freesurfer), [Run fMRIPREP apply](#running-fmriprep-apply), and [Run QSIprep](#Running-qsiprep).
+If your study collected fieldmaps for diffusion data and you plan to use them for distortion correction, you must ensure the ``IntendedFor`` field in your fieldmap files is correctly specified before running stage 1 [Run fMRIPREP Fit](#running-fmriprep-fit-includes-freesurfer), [Run fMRIPREP apply](#running-fmriprep-apply), and [Run QSIprep](#running-qsiprep).
 
 If IntendedFor is missing, fMRIPREP and QSIprep will still run, but it will **ignore** your fieldmap and apply ``synthetic fieldmap`` instead.
 
@@ -637,7 +638,7 @@ cat ${SCRATCH}/SCanD_project/logs/fieldmaps_qc_summary.log
 
 After setting up the SciNet environment and organizing your BIDS folder and `participants.tsv` file, you can run pipelines by stage using [Workflow automation (stage scripts)](Quick_start_workflow_automation.md), or run individual pipelines as described below.
 
-* Note: if you are running xcp-d pipeline (stage 3) for the first time, just make sure to run the codes to download the templateflow files before running the automated codes. You can find these codes below in [xcp-d](#Running-xcp-d) section.
+* Note: if you are running xcp-d pipeline (stage 3) for the first time, just make sure to run the codes to download the templateflow files before running the automated codes. You can find these codes below in [xcp-d](#running-xcp-d) section.
 
 
 # Running Pipelines and sharing results
@@ -909,7 +910,7 @@ If you're initiating the pipeline for the first time, it's crucial to acquire sp
 
 
 ```sh
-#First load a python module
+# First load a python module
 module load python/3.10
 
 # Create a directory for virtual environments if it doesn't exist
@@ -926,7 +927,7 @@ python3 -m pip install -U templateflow
 python -c "from templateflow.api import get; get(['fsaverage','fsLR', 'Fischer344','MNI152Lin','MNI152NLin2009aAsym','MNI152NLin2009aSym','MNI152NLin2009bAsym','MNI152NLin2009bSym','MNI152NLin2009cAsym','MNI152NLin2009cSym','MNI152NLin6Asym','MNI152NLin6Sym'])"
 ```
 ```sh
-#First load a python module
+# First load a python module
 module load python/3.11.5
 
 # Create a directory for virtual environments if it doesn't exist
@@ -1080,9 +1081,9 @@ If any participant has failed, amend `data/local/bids/participants.tsv` by **exc
 
 ## Syncing the data to the share directory
 
-This step calls some "group" level bids apps to build summary sheets and html index pages. It also moves a meta data, qc pages and a smaller subset of summary results into the data/share folder.
+This step calls group-level BIDS apps to build summary sheets and HTML index pages. It also copies metadata, QC pages, and a smaller subset of summary results into `data/share`.
 
-The Slurm extract job takes up to 8 hours on slurm (depending on how much data you are syncing). Run `06_extract_to_share_terminal.sh` after that job completes.
+Submit the Slurm extract job and run the login-node terminal script **together** (as in `stage_6.sh` and the commands below). The Slurm job may take up to ~8 hours on Slurm depending on dataset size; the terminal script runs immediately on the login node for MAGeTbrain QC, qsiprep metrics, and related steps.
 
 ```sh
 ## go to the repo and pull new changes

--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
-# SCanD_project
+# 🧠 SCanD_project
 
 This is the base repository for the **Schizophrenia Canadian Neuroimaging Database** preprocessing and sharing workflow. Clone or fork this repo once per study cohort, then run the staged pipelines on SciNet.
 
-## Pipeline overview
+> **New here?** Start with the [stage overview table](#the-general-overview-of-what-to-do) or [Workflow automation (stage scripts)](Quick_start_workflow_automation.md).
+
+## 📊 Pipeline overview
 
 The diagram below shows how major pipelines are grouped across stages (structural, functional, diffusion, and share/export). For step-by-step commands, use the [stage overview table](#the-general-overview-of-what-to-do) or [Workflow automation (stage scripts)](Quick_start_workflow_automation.md).
 
 ![SCanD / TIGRBIDS preprocessing workflow](tigrbids_flow.png)
 
-## Key documentation
+## 📚 Key documentation
 
-| Resource | Purpose |
-|----------|---------|
-| [Quick_start_workflow_automation.md](Quick_start_workflow_automation.md) | Workflow automation with `stage_*.sh` |
-| [QC_guide.md](QC_guide.md) | Visual QC criteria for pipeline HTML reports |
-| [share_folder.md](share_folder.md) | Checklist for `data/share` before consortium handoff |
+| | Resource | Purpose |
+|---|----------|---------|
+| 🚀 | [Quick_start_workflow_automation.md](Quick_start_workflow_automation.md) | Workflow automation with `stage_*.sh` |
+| 🔍 | [QC_guide.md](QC_guide.md) | Visual QC criteria for pipeline HTML reports |
+| ✅ | [share_folder.md](share_folder.md) | Checklist for `data/share` before consortium handoff |
 
-## Repository layout
+## 📁 Repository layout
 
 General folder structure for the repo (when all is run):
 
@@ -93,24 +95,24 @@ ${BASEDIR}
 
 Currently this repo is going to be set up for running things on SciNet Fir cluster - but we can adapt later to create local set-ups behind hospital firewalls if needed.
 
-# The general overview of what to do
+# 🗺️ The general overview of what to do
 
 | stage |  #	| Step	|   Estimated runtime 	|
 |---    |---	|---	|---	|
-| stage 0|   0a	|  [Setting up the SciNet environment](#setting-your-scinet-environment-and-prepare-dataset)	| ~30 minutes in terminal 	|
+| 🛠️ stage 0|   0a	|  [Setting up the SciNet environment](#setting-your-scinet-environment-and-prepare-dataset)	| ~30 minutes in terminal 	|
 |^ |  0b	|  [Organize your data into BIDS](#organize-your-data-into-bids) 	|   Varies by dataset size	|
 |^ |  0c	|  [Deface the BIDS data (if not done during step 1)](#deface-the-bids-data-if-not-done-during-step-1) 	|   	|
 |^ |  0d	|  [Move your BIDS data to the correct place and add labels to participants.tsv file](#put-your-bids-data-into-the-datalocal-folder-and-add-labels-to-participantstsv-file)	| Depends on data transfer time | 
 |^ |   0e	|  [Initializing nipoppy trackers](#initializing-nipoppy-trackers)	| ~2 minutes in terminal 	|
 |^ |   0f	|  [Edit fmap files](#1-edit-top-up-fmap-files-only)	| ~2 minutes in terminal 	|
-|stage 1|   01a	|  [Run MRIQC](#running-mriqc) 	|  ~8 hours on Slurm 	|
+| 1️⃣ stage 1|   01a	|  [Run MRIQC](#running-mriqc) 	|  ~8 hours on Slurm 	|
 |^ |  01b	|  [Run QSIprep](#running-qsiprep) 	|   ~6 hours on Slurm	|
 |^|   01c	|  [Run freesurfer](#running-freesurfer) 	|   ~23 hours on Slurm	|
 |^|   01d	|  [Run fMRIprep fit](#running-fmriprep-fit-includes-freesurfer) 	|   ~16 hours on Slurm	|
 |^ |  01e	|  [Run smriprep](#running-smriprep) 	|   ~10 hours on Slurm	|
 |^ |  01f	|  [Run magetbrain-init](#running-magetbrain-init) 	|   ~1 hour on Slurm	|
 |^ |  01g	|  [Check tsv file](#check-tsv-file) 	|    	|
-|stage 2|   02a	|  [Run fMRIprep apply](#running-fmriprep-apply) 	|  ~3 hours on Slurm 	|
+| 2️⃣ stage 2|   02a	|  [Run fMRIprep apply](#running-fmriprep-apply) 	|  ~3 hours on Slurm 	|
 |^ |   02b	|  [Run freesurfer atlas parcellate analysis](#running-freesurfer-atlas-parcellate-analysis) 	|  ~6 hours on Slurm 	|
 |^ |   02c	|  [Run ciftify-anat](#running-ciftify-anat) 	|  ~3 hours on Slurm 	|
 |^ |   02d	|  [Run qsirecon FSL](#running-qsirecon-fsl) 	|  ~20 minutes on Slurm 	|
@@ -118,20 +120,20 @@ Currently this repo is going to be set up for running things on SciNet Fir clust
 |^ |   02f	|  [Run tractography](#running-tractography) 	|  ~12 hours on Slurm 	|
 |^ |   02g	|  [Run magetbrain-register](#running-magetbrain-register) 	|  ~24 hours on Slurm 	|
 |^ |   02h  |  [Check tsv file](#check-tsv-file) 	|    	|
-|stage 3 |  03a	|  [Run xcp-d](#running-xcp-d) 	|  ~5 hours on Slurm  |
+| 3️⃣ stage 3 |  03a	|  [Run xcp-d](#running-xcp-d) 	|  ~5 hours on Slurm  |
 |^ |   03b  |  [Run xcp-noGSR](#running-xcp-nogsr) 	|  ~5 hours on Slurm  |
 |^ |   03c  |   [Run qsirecon dtifit](#running-qsirecon-dtifit) 	|  ~1 hour on Slurm 	|
 |^ |   03d	|  [Run noddi-registration](#running-noddi-registration) 	|  ~4 hours on Slurm 	|
 |^ |   03e	|  [Run glm-surface](#running-glm) 	|  ~30 minutes on Slurm 	|
 |^ |   03f	|  [Run magetbrain-vote](#running-magetbrain-vote) 	|  ~10 hours on Slurm 	|
 |^ |   03g	|  [Check tsv file](#check-tsv-file) 	|    	|
-|stage 4 |  04a |  [Run enigma-dti](#running-enigma-dti) 	|  ~1 hour on Slurm	| 
+| 4️⃣ stage 4 |  04a |  [Run enigma-dti](#running-enigma-dti) 	|  ~1 hour on Slurm	| 
 |^ |   04b	|  [Check tsv file](#check-tsv-file) 	|    	|
-|stage 5 |  05a |  [Run extract-noddi](#running-extract-noddi) 	|  ~3 hours on Slurm	|
+| 5️⃣ stage 5 |  05a |  [Run extract-noddi](#running-extract-noddi) 	|  ~3 hours on Slurm	|
 |^ |   05b	|  [Check tsv file](#check-tsv-file) 	|    	|
-|stage 6 |   06a	|  [Extract and share to consortium folder](#syncing-the-data-to-the-share-directory) 	|   ~8 hours on Slurm (Slurm job and login-node terminal script run together)	|
+| 📤 stage 6 |   06a	|  [Extract and share to consortium folder](#syncing-the-data-to-the-share-directory) 	|   ~8 hours on Slurm (Slurm job and login-node terminal script run together)	|
 
-# Setting your SciNet environment and prepare dataset
+# ⚙️ Setting your SciNet environment and prepare dataset
 
 ## Setting SciNet environment
 
@@ -634,14 +636,14 @@ The same summary is saved in a log file for later reference:
 cat ${SCRATCH}/SCanD_project/logs/fieldmaps_qc_summary.log
 ```
 
-# Quick Start - Workflow Automation
+# 🚀 Quick Start — Workflow Automation
 
 After setting up the SciNet environment and organizing your BIDS folder and `participants.tsv` file, you can run pipelines by stage using [Workflow automation (stage scripts)](Quick_start_workflow_automation.md), or run individual pipelines as described below.
 
 * Note: if you are running xcp-d pipeline (stage 3) for the first time, just make sure to run the codes to download the templateflow files before running the automated codes. You can find these codes below in [xcp-d](#running-xcp-d) section.
 
 
-# Running Pipelines and sharing results
+# 🔬 Running Pipelines and sharing results
 
 Participant-array pipelines chunk `participants.tsv` the same way as the `stage_*.sh` scripts. When submitting manually, source the shared helper first:
 
@@ -1072,14 +1074,14 @@ sbatch  ./code/05_extract_noddi_scinet.sh
 ```
 
 
-## Check tsv file
+## ✅ Check tsv file
 
 At any stage, before proceeding to the next stage and executing the codes for the subsequent phase, review the latest Neurobagel processing status file under `Neurobagel/derivatives/.processing_statuses/processing_status-*.tsv` (or the copy in `data/share/processing_status.tsv` after stage 6) for all pipelines from the previous stage. For instance, if you intend to execute stage 3 code, you must examine the processing status for all the pipelines in stage 2. If no participants have encountered failures, you may proceed with running the next stage. You can also upload your file to [Neurobagel Digest](https://digest.neurobagel.org/) to gain more insight into the status of your pipelines and to filter them for easier review.
 
 If any participant has failed, amend `data/local/bids/participants.tsv` by **excluding** the IDs of failed participants (keep only subjects you want to rerun). After rectifying the errors, rerun the pipeline with the updated participant list.
 
 
-## Syncing the data to the share directory
+## 📤 Syncing the data to the share directory
 
 This step calls group-level BIDS apps to build summary sheets and HTML index pages. It also copies metadata, QC pages, and a smaller subset of summary results into `data/share`.
 
@@ -1095,6 +1097,8 @@ source ./code/06_extract_to_share_terminal.sh
 ```
 
 When all pipelines are complete, verify `data/share` against [share_folder.md](share_folder.md). Use [QC_guide.md](QC_guide.md) for visual review of HTML QC reports before handoff. Replace `<groupName_studyName>` with your consortium group and study identifier (for example, `CMH_study2024`), then copy results to the shared space:
+
+🎉 **You're done!** Hand off your `data/share` folder to the consortium.
 
 ```sh
 cd ${SCRATCH}/SCanD_project


### PR DESCRIPTION
Normalize anchor links, IntendedFor wording, grammar, Slurm capitalization, glm container in layout tree, and clarify that Slurm extract plus terminal script are submitted together by design.