### PR TITLE
Share noddireg QC overlay NIfTIs in stage 3 and stage 6 extract scripts.

### DIFF
--- a/code/06_extract_to_share_slurm.sh
+++ b/code/06_extract_to_share_slurm.sh
@@ -399,6 +399,8 @@ rsync -a ${BASEDIR}/data/local/derivatives/freesurfer/7.4.1/00_group2_stats_tabl
 #running Noddi-registration
 NODDIREG_LOCAL_DIR="${BASEDIR}/data/local/derivatives/noddi_reg"
 NODDIREG_SHARE_DIR="${BASEDIR}/data/share/noddireg"
+QSIPREP_LOCAL_DIR="${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep"
+NODDI_QC_PARC="4S1056Parcels"
 
 if [ -d "${NODDIREG_LOCAL_DIR}" ]; then
     echo "Copying noddireg files"
@@ -412,9 +414,28 @@ if [ -d "${NODDIREG_LOCAL_DIR}" ]; then
             -type f \( \
                 -path "*/ses-*/dwi/*" -o \
                 -path "*/figures/*_desc-dsegtissue_model-noddi_density.png" -o \
-                -path "*/figures/*_desc-4S1056Parcels_model-noddi_mdp-*_qa.png" \
+                -path "*/figures/*_desc-${NODDI_QC_PARC}_model-noddi_mdp-*_qa.png" \
             \) \
             -exec rsync -a {} "${NODDIREG_SHARE_DIR}/${subject}/" \;
+
+        LAST_SES_DIR=$(find "${QSIPREP_LOCAL_DIR}/${subject}" -maxdepth 1 -type d -name "ses-*" | sort -V | tail -n 1)
+        if [ -n "${LAST_SES_DIR}" ]; then
+            DWIREF=$(find "${LAST_SES_DIR}/dwi" -maxdepth 1 -type f -name "*_space-T1w_dwiref.nii.gz" | head -n 1)
+            if [ -f "${DWIREF}" ]; then
+                rsync -a "${DWIREF}" "${NODDIREG_SHARE_DIR}/${subject}/"
+            else
+                echo "[WARN] Missing dwiref for ${subject} in ${LAST_SES_DIR}"
+            fi
+        else
+            echo "[WARN] No qsiprep sessions found for ${subject}"
+        fi
+
+        PARC_FILE="${NODDIREG_LOCAL_DIR}/${subject}/anat/${subject}_space-T1w_ref-dwiref_desc-${NODDI_QC_PARC}_dseg.nii.gz"
+        if [ -f "${PARC_FILE}" ]; then
+            rsync -a "${PARC_FILE}" "${NODDIREG_SHARE_DIR}/${subject}/"
+        else
+            echo "[WARN] Missing parcellation ${PARC_FILE}"
+        fi
     done
 else
     echo "No noddireg outputs found."

--- a/code/extract_to_share_stage3.sh
+++ b/code/extract_to_share_stage3.sh
@@ -117,6 +117,8 @@ fi
 
 NODDIREG_LOCAL_DIR="${BASEDIR}/data/local/derivatives/noddi_reg"
 NODDIREG_SHARE_DIR="${BASEDIR}/data/share/noddireg"
+QSIPREP_LOCAL_DIR="${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep"
+NODDI_QC_PARC="4S1056Parcels"
 
 if [ -d "${NODDIREG_LOCAL_DIR}" ]; then
     echo "Copying noddireg files"
@@ -130,9 +132,28 @@ if [ -d "${NODDIREG_LOCAL_DIR}" ]; then
             -type f \( \
                 -path "*/ses-*/dwi/*" -o \
                 -path "*/figures/*_desc-dsegtissue_model-noddi_density.png" -o \
-                -path "*/figures/*_desc-4S1056Parcels_model-noddi_mdp-*_qa.png" \
+                -path "*/figures/*_desc-${NODDI_QC_PARC}_model-noddi_mdp-*_qa.png" \
             \) \
             -exec rsync -a {} "${NODDIREG_SHARE_DIR}/${subject}/" \;
+
+        LAST_SES_DIR=$(find "${QSIPREP_LOCAL_DIR}/${subject}" -maxdepth 1 -type d -name "ses-*" | sort -V | tail -n 1)
+        if [ -n "${LAST_SES_DIR}" ]; then
+            DWIREF=$(find "${LAST_SES_DIR}/dwi" -maxdepth 1 -type f -name "*_space-T1w_dwiref.nii.gz" | head -n 1)
+            if [ -f "${DWIREF}" ]; then
+                rsync -a "${DWIREF}" "${NODDIREG_SHARE_DIR}/${subject}/"
+            else
+                echo "[WARN] Missing dwiref for ${subject} in ${LAST_SES_DIR}"
+            fi
+        else
+            echo "[WARN] No qsiprep sessions found for ${subject}"
+        fi
+
+        PARC_FILE="${NODDIREG_LOCAL_DIR}/${subject}/anat/${subject}_space-T1w_ref-dwiref_desc-${NODDI_QC_PARC}_dseg.nii.gz"
+        if [ -f "${PARC_FILE}" ]; then
+            rsync -a "${PARC_FILE}" "${NODDIREG_SHARE_DIR}/${subject}/"
+        else
+            echo "[WARN] Missing parcellation ${PARC_FILE}"
+        fi
     done
 else
     echo "No noddireg outputs found."


### PR DESCRIPTION
Copy last-session qsiprep dwiref and 4S1056 dwiref-space parcellation alongside existing noddireg TSVs and QA PNGs for consortium overlay QC.