### PR TITLE
Remove misleading and redundant comments from SciNet pipeline scripts.

### DIFF
--- a/code/01_fmriprep_fit_scinet.sh
+++ b/code/01_fmriprep_fit_scinet.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 #SBATCH --job-name=fmriprep_fit
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=32
 #SBATCH --time=10:00:00
 #SBATCH --mem-per-cpu=10000
 
-SUB_SIZE=1 ## number of subjects to run
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,30 +20,22 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 
 module load apptainer/1.3.5
 
-# input is BIDS_DIR this is where the data downloaded from openneuro went
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
-## these folders envs need to be set up for this script to run properly 
 export FMRIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/fmriprep-25.2.4.simg
 
 
-## setting up the output folders
-export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/fmriprep/25.2.4  # use if version of fmriprep >=20.2
-#export OUTPUT_DIR=${BASEDIR}/data/local/ # use if version of fmriprep <=21.0
+export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/fmriprep/25.2.4
 
-# export LOCAL_FREESURFER_DIR=${SCRATCH}/${STUDY}/data/derived/freesurfer-6.0.1
 export WORK_DIR=${SLURM_TMPDIR}/SCanD/fmriprep
 export LOGS_DIR=${BASEDIR}/logs
-mkdir -vp ${OUTPUT_DIR} ${WORK_DIR} # ${LOCAL_FREESURFER_DIR}
+mkdir -vp ${OUTPUT_DIR} ${WORK_DIR}
 
-## get the subject list from a combo of the array id, the participants.tsv and the chunk 
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
 N_SUBJECTS=$(( $( wc -l ${BIDS_DIR}/participants.tsv | cut -f1 -d' ' ) - 1 ))
@@ -59,17 +48,7 @@ else
     SUBJECTS=`sed -n -E "s/sub-(\S*)\>.*/\1/gp" ${BIDS_DIR}/participants.tsv | head -n ${bigger_bit} | tail -n ${SUB_SIZE}`
 fi
 
-## set singularity environment variables that will point to the freesurfer license and the templateflow bits
-# export SINGULARITYENV_TEMPLATEFLOW_HOME=/home/fmriprep/.cache/templateflow
-# Make sure FS_LICENSE is defined in the container.
 export APPTAINERENV_FS_LICENSE=/home/fmriprep/.freesurfer.txt
-
-# # Remove IsRunning files from FreeSurfer
-# for subject in $SUBJECTS: do
-#     find ${LOCAL_FREESURFER_DIR}/sub-$subject/ -name "*IsRunning*" -type f -delete
-# done
-
-
 
 
 singularity run --cleanenv \
@@ -90,12 +69,10 @@ singularity run --cleanenv \
     --use-syn-sdc \
     --notrack \
     --ignore slicetiming \
-    --level resampling 
+    --level resampling
 
-# tip: add this line to the above command if skull stripping has already been done
-#   --skull-strip-t1w force \ # uncomment this line if skull stripping has already been done
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \

--- a/code/01_freesurfer_long_scinet.sh
+++ b/code/01_freesurfer_long_scinet.sh
@@ -1,20 +1,16 @@
 #!/bin/bash
 #SBATCH --job-name=freesurfer
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=8
 #SBATCH --time=20:00:00
 #SBATCH --mem-per-cpu=8000
 
-SUB_SIZE=1 ## number of subjects to run
+SUB_SIZE=1
 
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
-
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,28 +19,20 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 
 module load apptainer/1.3.5
-# input is BIDS_DIR this is where the data downloaded from openneuro went
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
-## these folders envs need to be set up for this script to run properly 
 export FMRIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/freesurfer-7.4.1.simg
 
 
-## setting up the output folders
-export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/freesurfer/7.4.1  # use if version of fmriprep >=20.2
-#export OUTPUT_DIR=${BASEDIR}/data/local/ # use if version of fmriprep <=21.0
+export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/freesurfer/7.4.1
 
-# export LOCAL_FREESURFER_DIR=${SCRATCH}/${STUDY}/data/derived/freesurfer-6.0.1
 export LOGS_DIR=${BASEDIR}/logs
-mkdir -vp ${OUTPUT_DIR} ${LOGS_DIR} # ${LOCAL_FREESURFER_DIR}
+mkdir -vp ${OUTPUT_DIR} ${LOGS_DIR}
 
-## get the subject list from a combo of the array id, the participants.tsv and the chunk 
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
 
@@ -58,15 +46,8 @@ else
     SUBJECTS=`sed -n -E "s/sub-(\S*)\>.*/\1/gp" ${BIDS_DIR}/participants.tsv | head -n ${bigger_bit} | tail -n ${SUB_SIZE}`
 fi
 
-## set singularity environment variables that will point to the freesurfer license and the templateflow bits
-# export SINGULARITYENV_TEMPLATEFLOW_HOME=/home/fmriprep/.cache/templateflow
-# Make sure FS_LICENSE is defined in the container.
 export APPTAINERENV_FS_LICENSE=/home/freesurfer/.freesurfer.txt
 
-# # Remove IsRunning files from FreeSurfer
-# for subject in $SUBJECTS: do
-#     find ${LOCAL_FREESURFER_DIR}/sub-$subject/ -name "*IsRunning*" -type f -delete
-# done
 
 export ORIG_FS_LICENSE=${BASEDIR}/templates/.freesurfer.txt
 
@@ -80,10 +61,8 @@ singularity run --cleanenv \
     --participant_label ${SUBJECTS} \
     --skip_bids_validator \
     --license_file /li \
-    --n_cpus 80  
+    --n_cpus 80
 
-# tip: add this line to the above command if skull stripping has already been done
-#   --skull-strip-t1w force \ # uncomment this line if skull stripping has already been done
 
 ## nipoppy trackers
 
@@ -110,7 +89,7 @@ singularity exec \
   ${BASEDIR}/containers/nipoppy.sif /bin/bash -c '
     set -euo pipefail
 
-    cd "$BASEDIR/Neurobagel"    
+    cd "$BASEDIR/Neurobagel"
     mkdir -p derivatives/freesurferlong/7.4.1/output/
     ls -al derivatives/freesurferlong/7.4.1/output/
     ln -s "$BASEDIR/data/local/derivatives/freesurfer/7.4.1/"* derivatives/freesurferlong/7.4.1/output/ || true

--- a/code/01_magetbrain_init_scinet.sh
+++ b/code/01_magetbrain_init_scinet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=magetbrain_init
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=4
 #SBATCH --time=03:00:00
@@ -67,7 +67,7 @@ if [[ -f "$DEMOGRAPHIC_FILE" ]]; then
 
     # Combine males and females into one array
     selected_subjects=("${selected_males_for_templates[@]}" "${selected_females_for_templates[@]}")
-    
+
 else
     selected_subjects=($(tail -n +2 "$BIDS_DIR/participants.tsv" | cut -f1 | shuf -n 21))
 fi
@@ -176,7 +176,7 @@ rm -rf ${INPUT_DIR}/templates/brains/*T1w.mnc
 cp -r /scratch/arisvoin/shared/templateflow/atlases  "$INPUT_DIR/"
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -185,10 +185,10 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/magetbraininit/0.1.0/output/
     ls -al derivatives/magetbraininit/0.1.0/output/
     ln -s "$BASEDIR/data/local/derivatives/MAGeTbrain/magetbrain_data/"* derivatives/magetbraininit/0.1.0/output/ || true
 
-    nipoppy track  --pipeline magetbraininit   --pipeline-version 0.1.0 
+    nipoppy track  --pipeline magetbraininit   --pipeline-version 0.1.0
   '

--- a/code/01_mriqc_scinet.sh
+++ b/code/01_mriqc_scinet.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 #SBATCH --job-name=mriqc
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=16
 #SBATCH --time=08:00:00
 #SBATCH --mem-per-cpu=16000
 
-SUB_SIZE=1 ## number of subjects to run
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -24,27 +21,20 @@ function cleanup_ramdisk {
 }
 module load apptainer/1.3.5
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 
-# input is BIDS_DIR this is where the data downloaded from openneuro went
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
-## these folders envs need to be set up for this script to run properly 
 export FMRIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/mriqc-24.0.0.simg
 
 
-## setting up the output folders
-# export OUTPUT_DIR=${BASEDIR}/data/local/fmriprep  # use if version of fmriprep >=20.2
 export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/mriqc/24.0.0 # use if version of fmriprep <=20.1
 
 export WORK_DIR=${SLURM_TMPDIR}/SCanD/mriqc
 export LOGS_DIR=${BASEDIR}/logs
-mkdir -vp ${OUTPUT_DIR} ${WORK_DIR} # ${LOCAL_FREESURFER_DIR}
+mkdir -vp ${OUTPUT_DIR} ${WORK_DIR}
 
-## get the subject list from a combo of the array id, the participants.tsv and the chunk size
 
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
@@ -57,8 +47,6 @@ if [ "$SLURM_ARRAY_TASK_ID" -eq "$array_job_length" ]; then
 else
     SUBJECTS=`sed -n -E "s/sub-(\S*)\>.*/\1/gp" ${BIDS_DIR}/participants.tsv | head -n ${bigger_bit} | tail -n ${SUB_SIZE}`
 fi
-
-
 
 
 singularity run --cleanenv \
@@ -78,8 +66,7 @@ singularity run --cleanenv \
     --no-sub
 
 
-
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \

--- a/code/01_qsiprep_scinet.sh
+++ b/code/01_qsiprep_scinet.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 #SBATCH --job-name=qsiprep
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=10
 #SBATCH --time=06:00:00
 #SBATCH --mem-per-cpu=4000
 
-SUB_SIZE=1 ## number of subjects to run is 1 because there are multiple tasks/run that will run in parallel 
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,26 +20,20 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 
 module load apptainer/1.3.5
-# input is BIDS_DIR this is where the data downloaded from openneuro went
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
-## these folders envs need to be set up for this script to run properly 
 export QSIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
 
-## setting up the output folders
-# export OUTPUT_DIR=${BASEDIR}/data/local/fmriprep  # use if version of fmriprep >=20.2
 export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0 # use if version of fmriprep <=20.1
 
 # adding random string (project_id) to BBUFFER folder to prevent conflicts between projects
 export WORK_DIR=${SLURM_TMPDIR}/SCanD/qsiprep
 export LOGS_DIR=${BASEDIR}/logs
-mkdir -vp ${OUTPUT_DIR} ${WORK_DIR} # ${LOCAL_FREESURFER_DIR}
+mkdir -vp ${OUTPUT_DIR} ${WORK_DIR}
 
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
@@ -107,8 +98,6 @@ fi
 echo "SDC flags: ${SDC_ARGS}"
 
 
-## set singularity environment variables that will point to the freesurfer license and the templateflow bits
-# Make sure FS_LICENSE is defined in the container.
 export SINGULARITYENV_FS_LICENSE=/home/qsiprep/.freesurfer.txt
 
 singularity run --cleanenv \
@@ -132,7 +121,7 @@ singularity run --cleanenv \
    ${SDC_ARGS}
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -142,7 +131,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/qsiprep/0.22.0/output/
     ls -al derivatives/qsiprep/0.22.0/output/
 

--- a/code/01_smriprep_scinet.sh
+++ b/code/01_smriprep_scinet.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 #SBATCH --job-name=smriprep
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=16
 #SBATCH --time=10:00:00
 #SBATCH --mem-per-cpu=8000
 
-SUB_SIZE=1 ## number of subjects to run
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -25,28 +22,21 @@ function cleanup_ramdisk {
 
 module load apptainer/1.3.5
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 
 
-# input is BIDS_DIR this is where the data downloaded from openneuro went
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
-## these folders envs need to be set up for this script to run properly 
 export SMRIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/fmriprep-25.2.4.simg
 
 
-## setting up the output folders
-export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/smriprep/25.2.4 
+export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/smriprep/25.2.4
 
-# export LOCAL_FREESURFER_DIR=${SCRATCH}/${STUDY}/data/derived/freesurfer-6.0.1
 export WORK_DIR=${SLURM_TMPDIR}/SCanD/smriprep
 export LOGS_DIR=${BASEDIR}/logs
-mkdir -vp ${OUTPUT_DIR} ${WORK_DIR} # ${LOCAL_FREESURFER_DIR}
+mkdir -vp ${OUTPUT_DIR} ${WORK_DIR}
 
-## get the subject list from a combo of the array id, the participants.tsv and the chunk 
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
 N_SUBJECTS=$(( $( wc -l ${BIDS_DIR}/participants.tsv | cut -f1 -d' ' ) - 1 ))
@@ -71,7 +61,7 @@ singularity exec --cleanenv \
     smriprep /bids /derived participant --participant_label ${SUBJECTS} -w /work  --omp-nthreads 8  --nthreads 40  --notrack --fs-license-file /li
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \

--- a/code/02_amico_noddi_scinet.sh
+++ b/code/02_amico_noddi_scinet.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 #SBATCH --job-name=amico_noddi
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=8
 #SBATCH --time=02:00:00
 #SBATCH --mem-per-cpu=4000
 
-SUB_SIZE=1 ## number of subjects to run is 1 because there are multiple tasks/run that will run in parallel 
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,12 +20,9 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 
 module load apptainer/1.3.5
-# input is BIDS_DIR this is where the data downloaded from openneuro went
 export BIDS_DIR=${BASEDIR}/data/local/bids
 export QSIPREP_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep
 export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
@@ -50,7 +44,6 @@ if [ "$SLURM_ARRAY_TASK_ID" -eq "$array_job_length" ]; then
 else
     SUBJECTS=`sed -n -E "s/sub-(\S*)\>.*/\1/gp" ${BIDS_DIR}/participants.tsv | head -n ${bigger_bit} | tail -n ${SUB_SIZE}`
 fi
-
 
 
 export SINGULARITYENV_FS_LICENSE=${BASEDIR}/templates/.freesurfer.txt
@@ -76,7 +69,7 @@ singularity run --cleanenv \
   --notrack
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -86,7 +79,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/amiconoddi/0.22.0/output/
     ls -al derivatives/amiconoddi/0.22.0/output/
 

--- a/code/02_ciftify_anat_scinet.sh
+++ b/code/02_ciftify_anat_scinet.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 #SBATCH --job-name=ciftify
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=8
 #SBATCH --time=08:00:00
 #SBATCH --mem-per-cpu=4000
 
-SUB_SIZE=1 ## number of subjects to run
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,8 +20,6 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 module load apptainer/1.3.5
 
@@ -34,7 +29,7 @@ export ORIG_FS_LICENSE=${BASEDIR}/templates/.freesurfer.txt
 export SUBJECTS_DIR=${BASEDIR}/data/local/derivatives/freesurfer/7.4.1
 export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/ciftify
 export LOGS_DIR=${BASEDIR}/logs
-mkdir -vp ${OUTPUT_DIR} 
+mkdir -vp ${OUTPUT_DIR}
 
 
 if compgen -G "${SUBJECTS_DIR}/*long*" > /dev/null; then
@@ -47,7 +42,7 @@ SUBJECTS=("${SUBJECT_FOLDERS[@]##*/}")  # Just the folder names, like sub-CMH000
 
 SUBJECT_INDEX=${SLURM_ARRAY_TASK_ID}
 SELECTED_SUBJECT=${SUBJECTS[$SUBJECT_INDEX]}
- 
+
 singularity exec --cleanenv \
     -B ${SUBJECTS_DIR}:/freesurfer \
     -B ${OUTPUT_DIR}:/out \
@@ -69,7 +64,7 @@ else
 fi
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -79,7 +74,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/ciftify/1.3.2/output/
     ls -al derivatives/ciftify/1.3.2/output/
 

--- a/code/02_fmriprep_apply_scinet.sh
+++ b/code/02_fmriprep_apply_scinet.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 #SBATCH --job-name=fmriprep_apply
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=32
 #SBATCH --time=08:00:00
 #SBATCH --mem-per-cpu=12000
 
-SUB_SIZE=1 ## number of subjects to run is 1 because there are multiple tasks/run that will run in parallel 
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,27 +20,20 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 
 module load apptainer/1.3.5
-# input is BIDS_DIR this is where the data downloaded from openneuro went
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
-## these folders envs need to be set up for this script to run properly 
 export FMRIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/fmriprep-25.2.4.simg
 
-## setting up the output folders
-export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/fmriprep/25.2.4  # use if version of fmriprep >=20.2
-#export OUTPUT_DIR=${BASEDIR}/data/local/ # use if version of fmriprep <=21.0
+export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/fmriprep/25.2.4
 
 export WORK_DIR=${SLURM_TMPDIR}/SCanD/fmriprep
 export LOGS_DIR=${BASEDIR}/logs
-mkdir -vp ${OUTPUT_DIR} ${WORK_DIR} # ${LOCAL_FREESURFER_DIR}
+mkdir -vp ${OUTPUT_DIR} ${WORK_DIR}
 
-## get the subject list from a combo of the array id, the participants.tsv and the chunk size
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
 N_SUBJECTS=$(( $( wc -l ${BIDS_DIR}/participants.tsv | cut -f1 -d' ' ) - 1 ))
@@ -55,16 +45,7 @@ if [ "$SLURM_ARRAY_TASK_ID" -eq "$array_job_length" ]; then
 else
     SUBJECTS=`sed -n -E "s/sub-(\S*)\>.*/\1/gp" ${BIDS_DIR}/participants.tsv | head -n ${bigger_bit} | tail -n ${SUB_SIZE}`
 fi
-## set singularity environment variables that will point to the freesurfer license and the templateflow bits
-# Make sure FS_LICENSE is defined in the container.
 export APPTAINERENV_FS_LICENSE=/home/fmriprep/.freesurfer.txt
-
-# # Remove IsRunning files from FreeSurfer
-# for subject in $SUBJECTS: do
-#     find ${LOCAL_FREESURFER_DIR}/sub-$subject/ -name "*IsRunning*" -type f -delete
-# done
-
-
 
 
 singularity run --cleanenv \
@@ -81,12 +62,10 @@ singularity run --cleanenv \
     --cifti-output 91k \
     --use-syn-sdc \
     --ignore slicetiming \
-    --level full 
-
-# note, if you have top-up fieldmaps than you can uncomment the last two lines of the above script
+    --level full
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -96,7 +75,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/fmriprepapply/25.2.4/output/
     ls -al derivatives/fmriprepapply/25.2.4/output/
 

--- a/code/02_freesurfer_atlas_parcellate_scinet.sh
+++ b/code/02_freesurfer_atlas_parcellate_scinet.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 #SBATCH --job-name=freesurfer_parcellate
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=8
 #SBATCH --time=06:00:00
 #SBATCH --mem-per-cpu=4000
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -18,13 +16,11 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 
 module load apptainer/1.3.5
 export BIDS_DIR=${BASEDIR}/data/local/bids
-export SING_CONTAINER=${BASEDIR}/containers/freesurfer-7.4.1.simg 
+export SING_CONTAINER=${BASEDIR}/containers/freesurfer-7.4.1.simg
 export LOGS_DIR=${BASEDIR}/logs
 export ORIG_FS_LICENSE=${BASEDIR}/templates/.freesurfer.txt
 export SUBJECTS_DIR=${BASEDIR}/data/local/derivatives/freesurfer/7.4.1
@@ -64,7 +60,7 @@ singularity exec \
     for SUBJECT in $SUBJECT_BATCH; do
 
       SUBJECT_LONG_DIRS=$(find $SUBJECTS_DIR -maxdepth 1 -name "${SUBJECT}*.long.${SUBJECT}" -type d)
-      
+
       if [[ -z "$SUBJECT_LONG_DIRS" ]]; then
         SUBJECT_LONG_DIRS=$(find "$SUBJECTS_DIR" -maxdepth 1 -name "${SUBJECT}*" -type d)
       fi
@@ -145,7 +141,7 @@ singularity exec \
 EOF
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 SUBJECT_LONG_DIRS=$(find "$SUBJECTS_DIR" -maxdepth 1 -type d -name "*.long.*" | head -n 1)
 
@@ -170,7 +166,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/freesurferparcellate/7.4.1/output/
     ls -al derivatives/freesurferparcellate/7.4.1/output/
 

--- a/code/02_magetbrain_register_scinet.sh
+++ b/code/02_magetbrain_register_scinet.sh
@@ -34,7 +34,7 @@ singularity run \
        --stage-voting-walltime 24:00:00
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -43,7 +43,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/magetbrainregister/0.1.0/output/
     ls -al derivatives/magetbrainregister/0.1.0/output/
 

--- a/code/02_qsirecon_FSL_scinet.sh
+++ b/code/02_qsirecon_FSL_scinet.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 #SBATCH --job-name=qsirecon_fsl
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=8
 #SBATCH --time=01:00:00
 #SBATCH --mem-per-cpu=4000
 
-SUB_SIZE=1 ## number of subjects to run is 1 because there are multiple tasks/run that will run in parallel 
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,26 +20,20 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 module load apptainer/1.3.5
 
-# input is BIDS_DIR this is where the data downloaded from openneuro went
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
-## these folders envs need to be set up for this script to run properly 
 export QSIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
 
-## setting up the output folders
-export OUTPUT_DIR=${BASEDIR}/data/local  # use if version of fmriprep >=20.2
+export OUTPUT_DIR=${BASEDIR}/data/local
 export QSIPREP_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep # use if version of fmriprep <=20.1
 
-# export LOCAL_FREESURFER_DIR=${SCRATCH}/${STUDY}/data/derived/freesurfer-6.0.1
 export WORK_DIR=${SLURM_TMPDIR}/SCanD/qsiprep
 export LOGS_DIR=${BASEDIR}/logs
-mkdir -vp ${OUTPUT_DIR} ${WORK_DIR} # ${LOCAL_FREESURFER_DIR}
+mkdir -vp ${OUTPUT_DIR} ${WORK_DIR}
 
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
@@ -56,8 +47,6 @@ else
     SUBJECTS=`sed -n -E "s/sub-(\S*)\>.*/\1/gp" ${BIDS_DIR}/participants.tsv | head -n ${bigger_bit} | tail -n ${SUB_SIZE}`
 fi
 
-## set singularity environment variables that will point to the freesurfer license and the templateflow bits
-# Make sure FS_LICENSE is defined in the container.
 
 export fs_license=${BASEDIR}/templates/.freesurfer.txt
 
@@ -83,7 +72,7 @@ singularity run --cleanenv \
     --fs-license-file /li \
     --notrack
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -93,7 +82,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/qsireconfsl/0.22.0/output/
     ls -al derivatives/qsireconfsl/0.22.0/output/
 

--- a/code/02_tractography_multi_scinet.sh
+++ b/code/02_tractography_multi_scinet.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 #SBATCH --job-name=tractography
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=32
 #SBATCH --time=23:00:00
 #SBATCH --mem-per-cpu=4000
 
-SUB_SIZE=1 ## number of subjects to run is 1 because there are multiple tasks/run that will run in parallel 
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,20 +20,14 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 module load apptainer/1.3.5
 
-# input is BIDS_DIR this is where the data downloaded from openneuro went
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
-## these folders envs need to be set up for this script to run properly 
 export QSIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
 
-## setting up the output folders
-# export OUTPUT_DIR=${BASEDIR}/data/local/fmriprep  # use if version of fmriprep >=20.2
 export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/tractography # use if version of fmriprep <=20.1
 
 export QSIPREP_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep
@@ -48,10 +39,9 @@ for d in ${FREESURFER_DIR}/sub-*_ses-*; do
   ln -sfn "$d" "$subj"
 done
 
-# export LOCAL_FREESURFER_DIR=${SCRATCH}/${STUDY}/data/derived/freesurfer-6.0.1
 export WORK_DIR=${SLURM_TMPDIR}/SCanD/qsiprep
 export LOGS_DIR=${BASEDIR}/logs
-mkdir -vp ${OUTPUT_DIR} ${WORK_DIR} # ${LOCAL_FREESURFER_DIR}
+mkdir -vp ${OUTPUT_DIR} ${WORK_DIR}
 
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
@@ -65,8 +55,6 @@ else
     SUBJECTS=`sed -n -E "s/sub-(\S*)\>.*/\1/gp" ${BIDS_DIR}/participants.tsv | head -n ${bigger_bit} | tail -n ${SUB_SIZE}`
 fi
 
-## set singularity environment variables that will point to the freesurfer license and the templateflow bits
-# Make sure FS_LICENSE is defined in the container.
 export ORIG_FS_LICENSE=${BASEDIR}/templates/.freesurfer.txt
 
 singularity run --cleanenv \
@@ -88,10 +76,10 @@ singularity run --cleanenv \
     --freesurfer-input /freesurfer \
     --fs-license-file /li \
     --skip-odf-reports \
-    --output-resolution 2.0 
+    --output-resolution 2.0
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -101,7 +89,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/tractographymulti/0.22.0/output/
     ls -al derivatives/tractographymulti/0.22.0/output/
 

--- a/code/02_tractography_single_scinet.sh
+++ b/code/02_tractography_single_scinet.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 #SBATCH --job-name=tractography
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=32
 #SBATCH --time=23:00:00
 #SBATCH --mem-per-cpu=4000
 
-SUB_SIZE=1 ## number of subjects to run is 1 because there are multiple tasks/run that will run in parallel 
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,20 +20,14 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 module load apptainer/1.3.5
 
-# input is BIDS_DIR this is where the data downloaded from openneuro went
 export BIDS_DIR=${BASEDIR}/data/local/bids
 
-## these folders envs need to be set up for this script to run properly 
 export QSIPREP_HOME=${BASEDIR}/templates
 export SING_CONTAINER=${BASEDIR}/containers/qsiprep-0.22.0.sif
 
-## setting up the output folders
-# export OUTPUT_DIR=${BASEDIR}/data/local/fmriprep  # use if version of fmriprep >=20.2
 export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/tractography # use if version of fmriprep <=20.1
 
 export QSIPREP_DIR=${BASEDIR}/data/local/derivatives/qsiprep/0.22.0/qsiprep
@@ -48,10 +39,9 @@ for d in ${FREESURFER_DIR}/sub-*_ses-*; do
   ln -sfn "$d" "$subj"
 done
 
-# export LOCAL_FREESURFER_DIR=${SCRATCH}/${STUDY}/data/derived/freesurfer-6.0.1
 export WORK_DIR=${SLURM_TMPDIR}/SCanD/qsiprep
 export LOGS_DIR=${BASEDIR}/logs
-mkdir -vp ${OUTPUT_DIR} ${WORK_DIR} # ${LOCAL_FREESURFER_DIR}
+mkdir -vp ${OUTPUT_DIR} ${WORK_DIR}
 
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
@@ -65,8 +55,6 @@ else
     SUBJECTS=`sed -n -E "s/sub-(\S*)\>.*/\1/gp" ${BIDS_DIR}/participants.tsv | head -n ${bigger_bit} | tail -n ${SUB_SIZE}`
 fi
 
-## set singularity environment variables that will point to the freesurfer license and the templateflow bits
-# Make sure FS_LICENSE is defined in the container.
 export ORIG_FS_LICENSE=${BASEDIR}/templates/.freesurfer.txt
 
 singularity run --cleanenv \
@@ -88,10 +76,10 @@ singularity run --cleanenv \
     --freesurfer-input /freesurfer \
     --fs-license-file /li \
     --skip-odf-reports \
-    --output-resolution 2.0 
+    --output-resolution 2.0
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -101,7 +89,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/tractographysingle/0.22.0/output/
     ls -al derivatives/tractographysingle/0.22.0/output/
 

--- a/code/03_glm_surface_scinet.sh
+++ b/code/03_glm_surface_scinet.sh
@@ -6,7 +6,7 @@
 #SBATCH --time=08:00:00
 #SBATCH --mem-per-cpu=8000
 
-SUB_SIZE=1 ## number of subjects to run is 1 because there are multiple tasks/run that will run in parallel
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 BASEDIR=${SLURM_SUBMIT_DIR}
 
@@ -18,8 +18,6 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 
 module load apptainer/1.3.5
@@ -63,7 +61,7 @@ echo singularity run --cleanenv \
     --participant-label ${SUBJECTS} \
     --model /model \
     --drop-duration 4 \
-    --fwhm 6 
+    --fwhm 6
 
 singularity run --cleanenv \
     -B ${BIDS_DIR}:/bids \
@@ -78,7 +76,7 @@ singularity run --cleanenv \
     --drop-duration 4 \
     --fwhm 6
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \

--- a/code/03_magetbrain_vote_scinet.sh
+++ b/code/03_magetbrain_vote_scinet.sh
@@ -47,7 +47,7 @@ singularity run \
        --stage-voting-walltime 24:00:00
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -57,7 +57,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/magetbrainvote/0.1.0/output/
     ls -al derivatives/magetbrainvote/0.1.0/output/
 

--- a/code/03_qsirecon_dtifit_scinet.sh
+++ b/code/03_qsirecon_dtifit_scinet.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #SBATCH --job-name=qsirecon_dtifit
-#SBATCH --output=logs/%x_%j.out 
+#SBATCH --output=logs/%x_%j.out
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=8
 #SBATCH --time=02:00:00
 #SBATCH --mem-per-cpu=4000
 
-SUB_SIZE=1 ## number of subjects to run is 1 because there are multiple tasks/run that will run in parallel 
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
 BASEDIR=${SLURM_SUBMIT_DIR}

--- a/code/03_xcp_noGSR_scinet.sh
+++ b/code/03_xcp_noGSR_scinet.sh
@@ -6,15 +6,12 @@
 #SBATCH --time=04:00:00
 #SBATCH --mem-per-cpu=4000
 
-SUB_SIZE=1 ## number of subjects to run is 1 because there are multiple tasks/run that will run in parallel
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,8 +20,6 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 
 module load apptainer/1.3.5
@@ -33,7 +28,6 @@ export BIDS_DIR=${BASEDIR}/data/local/bids
 export SING_CONTAINER=${BASEDIR}/containers/xcp_d-0.7.3.simg
 
 
-## setting up the output folders
 export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/xcp_noGSR
 export FMRI_DIR=${BASEDIR}/data/local/derivatives/fmriprep/25.2.4/
 export CONFOUND_DIR=${BASEDIR}/data/local/derivatives/fmriprep/25.2.4/custom_confounds/
@@ -45,9 +39,6 @@ export FS_LICENSE=${BASEDIR}/templates/.freesurfer.txt
 mkdir -vp ${OUTPUT_DIR} ${WORK_DIR} ${CONFOUND_DIR}
 
 
-# SUBJECTS=$(awk -F'\t' 'NR>1 {print $1}' ${BIDS_DIR}/participants.tsv)
-
-## get the subject list from a combo of the array id, the participants.tsv and the chunk size
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
 N_SUBJECTS=$(( $( wc -l ${BIDS_DIR}/participants.tsv | cut -f1 -d' ' ) - 1 ))
@@ -141,9 +132,8 @@ ${SING_CONTAINER} \
     --fs-license-file /li \
     --notrack
 
-# note, if you have top-up fieldmaps than you can uncomment the last two lines of the above script
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -153,7 +143,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/xcpnogsr/0.7.3/output/
     ls -al derivatives/xcpnogsr/0.7.3/output/
 

--- a/code/03_xcp_scinet.sh
+++ b/code/03_xcp_scinet.sh
@@ -6,15 +6,12 @@
 #SBATCH --time=04:00:00
 #SBATCH --mem-per-cpu=4000
 
-SUB_SIZE=1 ## number of subjects to run is 1 because there are multiple tasks/run that will run in parallel
+SUB_SIZE=1
 export THREADS_PER_COMMAND=2
 
-####----### the next bit only works IF this script is submitted from the $BASEDIR/$OPENNEURO_DS folder...
 
-## set the second environment variable to get the base directory
 BASEDIR=${SLURM_SUBMIT_DIR}
 
-## set up a trap that will clear the ramdisk if it is not cleared
 function cleanup_ramdisk {
     echo -n "Cleaning up ramdisk directory /$SLURM_TMPDIR/ on "
     date
@@ -23,8 +20,6 @@ function cleanup_ramdisk {
     date
 }
 
-#trap the termination signal, and call the function 'trap_term' when
-# that happens, so results may be saved.
 trap "cleanup_ramdisk" TERM
 module load apptainer/1.3.5
 
@@ -33,7 +28,6 @@ export BIDS_DIR=${BASEDIR}/data/local/bids
 export SING_CONTAINER=${BASEDIR}/containers/xcp_d-0.7.3.simg
 
 
-## setting up the output folders
 export OUTPUT_DIR=${BASEDIR}/data/local/derivatives/xcp_d/0.7.3
 export FMRI_DIR=${BASEDIR}/data/local/derivatives/fmriprep/25.2.4
 
@@ -41,7 +35,6 @@ export WORK_DIR=${SLURM_TMPDIR}/SCanD/xcp
 export LOGS_DIR=${BASEDIR}/logs
 mkdir -vp ${OUTPUT_DIR} ${WORK_DIR}
 
-## get the subject list from a combo of the array id, the participants.tsv and the chunk size
 bigger_bit=`echo "($SLURM_ARRAY_TASK_ID + 1) * ${SUB_SIZE}" | bc`
 
 N_SUBJECTS=$(( $( wc -l ${BIDS_DIR}/participants.tsv | cut -f1 -d' ' ) - 1 ))
@@ -75,9 +68,8 @@ ${SING_CONTAINER} \
     --dummy-scans 3 \
     --notrack
 
-# note, if you have top-up fieldmaps than you can uncomment the last two lines of the above script
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -87,7 +79,7 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/xcpd/0.7.3/output/
     ls -al derivatives/xcpd/0.7.3/output/
 

--- a/code/04_enigma_dti_scinet.sh
+++ b/code/04_enigma_dti_scinet.sh
@@ -53,7 +53,7 @@ ${ENIGMA_DTI_CODES}/run_group_dtifit_qc.py --debug /dtifit_dir
 EOF
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -62,11 +62,11 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/enigmadti/0.1.1/output/
     ls -al derivatives/enigmadti/0.1.1/output/
 
     ln -s "$BASEDIR/data/local/enigmaDTI/" derivatives/enigmadti/0.1.1/output/ || true
 
-    nipoppy track  --pipeline enigmadti  --pipeline-version 0.1.1 
+    nipoppy track  --pipeline enigmadti  --pipeline-version 0.1.1
   '

--- a/code/05_extract_noddi_scinet.sh
+++ b/code/05_extract_noddi_scinet.sh
@@ -42,7 +42,7 @@ for subject in $SUBJECTS; do
 done
 
 
-## nipoppy trackers 
+## nipoppy trackers
 
 singularity exec \
   --env BASEDIR="$BASEDIR" \
@@ -52,11 +52,11 @@ singularity exec \
     set -euo pipefail
 
     cd "$BASEDIR/Neurobagel"
-    
+
     mkdir -p derivatives/extractnoddi/0.1.1/output/
     ls -al derivatives/extractnoddi/0.1.1/output/
 
     ln -s "$BASEDIR/data/local/derivatives/qsiprep/0.22.0/amico_noddi/qsirecon-NODDI/" derivatives/extractnoddi/0.1.1/output/ || true
 
-    nipoppy track  --pipeline extractnoddi  --pipeline-version 0.1.1 
+    nipoppy track  --pipeline extractnoddi  --pipeline-version 0.1.1
   '


### PR DESCRIPTION
Drop outdated top-up fieldmap notes in fMRIPrep/xcp-d scripts and other dead boilerplate that no longer matches the code.