### PR TITLE
Standardize extract-to-share terminal scripts on Python 3.11.5.

### DIFF
--- a/code/06_extract_to_share_terminal.sh
+++ b/code/06_extract_to_share_terminal.sh
@@ -18,7 +18,7 @@ rsync -a ${BASEDIR}/data/local/derivatives/MAGeTbrain/magetbrain_data/QC ${BASED
 
 
 ## Generate qsiprep motion metrics and extract NODDI indices
-module load  python/3.10
+module load python/3.11.5
 
 # Create a directory for virtual environments if it doesn't exist
 mkdir ${BASEDIR}/../.virtualenvs

--- a/code/extract_to_share_stage3_terminal.sh
+++ b/code/extract_to_share_stage3_terminal.sh
@@ -9,7 +9,7 @@ module load apptainer/1.3.5
 echo "Running qsiprep_metrics.csv"
 
 ## Generate qsiprep motion metrics and magetbrain
-module python/3.10.13
+module load python/3.11.5
 
 # Create a directory for virtual environments if it doesn't exist
 mkdir ${BASEDIR}/../.virtualenvs


### PR DESCRIPTION
Use python/3.11.5 consistently and fix the nibi stage3 script module load syntax.