### PR TITLE
Remove debug option from nipoppy track command

### DIFF
--- a/code/trackers.sh
+++ b/code/trackers.sh
@@ -100,7 +100,6 @@ singularity exec \
       nipoppy track \
         --pipeline qsiprep \
         --pipeline-version 0.22.0 \
-        --debug
   '
 
 singularity exec \


### PR DESCRIPTION
Removed the '--debug' option from the nipoppy track command.