### PR TITLE
Use relative FreeSurfer session symlinks in noddireg for Apptainer.

### DIFF
--- a/code/03_noddi_reg_scinet.sh
+++ b/code/03_noddi_reg_scinet.sh
@@ -67,7 +67,7 @@ for SUBJECT in ${SUBJECTS}; do
   for d in ${FREESURFER_DIR}/sub-${SUBJECT}_ses-*; do
     [[ -e "${d}" ]] || continue
     subj="${d%%_ses-*}"
-    ln -sfn "${d}" "${subj}"
+    ln -sfn "$(basename "${d}")" "${subj}"
   done
   fix_fs_surf_names "${SUBJECT}"
 done


### PR DESCRIPTION
Absolute symlink targets break ciftify inside the container bind mount when noddireg reruns.