### PR TITLE
Create noddireg FreeSurfer session symlink in FREESURFER_DIR

### DIFF
--- a/code/03_noddi_reg_scinet.sh
+++ b/code/03_noddi_reg_scinet.sh
@@ -147,7 +147,7 @@ for SUBJECT in ${SUBJECTS}; do
   for d in ${FREESURFER_DIR}/sub-${SUBJECT}_ses-*; do
     [[ -e "${d}" ]] || continue
     subj="$(basename "${d%%_ses-*}")"
-    ln -sfn "$(basename "${d}")" "${subj}"
+    ln -sfn "$(basename "${d}")" "${FREESURFER_DIR}/${subj}"
   done
   fix_fs_surf_names "${SUBJECT}"
 done


### PR DESCRIPTION
## Summary
- Put the noddireg FreeSurfer session symlink in `FREESURFER_DIR` instead of the job cwd.
- Keep the relative `basename` target so the link still resolves inside Apptainer.

## Test plan
- [ ] Confirm `ln -sfn "$(basename "${d}")" "${FREESURFER_DIR}/${subj}"` is in `code/03_noddi_reg_scinet.sh`
- [ ] On a cluster checkout, verify `sub-<id>` in the FreeSurfer dir points to `sub-<id>_ses-*` and that ciftify can read `mri/T1.mgz`